### PR TITLE
Fix handling of line break for multiline table columns issue #11

### DIFF
--- a/.playps.yml
+++ b/.playps.yml
@@ -1,0 +1,6 @@
+
+markdown:
+  # Should a line break be added after headers
+  sectionFormat: LineBreakAfterHeader
+  # Set the default infostring for fenced sections
+  infoString: text

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,9 @@
     "files.exclude": {
         ".vs": true,
         "artifacts": true,
-        "reports": true
+        "reports": true,
+        "**/bin/": true,
+        "**/obj/": true
     },
     "search.exclude": {
         "build": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Unreleased
 
+- Fix handling of line break for multiline table columns using a wrap separator
+- Added `New-PSDocumentOption` cmdlet to configure document generation
+- Added `-Option` parameter to `Invoke-PSDocument` cmdlet to accept configuration options
+- Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead
+
 ## v0.3.0
 
 - Improved `Yaml` block handling to allow YAML header to be defined throughout the document and merged when multiple blocks are defined

--- a/PSDocs.sln
+++ b/PSDocs.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2010
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PSDocs", "src\PSDocs\PSDocs.csproj", "{8BD3D495-74E7-4B34-9E69-D00A1AE53008}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|x64.Build.0 = Release|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BD3D495-74E7-4B34-9E69-D00A1AE53008}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {293CBC6B-EA22-460E-8294-807DF0C6008F}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The following language keywords are used by the `PSDocs` module:
 - [Code](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#code) - Inserts a block of code
 - [Note](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#note) - Inserts a note using DocFx formatted markdown (DFM)
 - [Warning](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#warning) - Inserts a warning using DocFx formatted markdown (DFM)
-- [Yaml](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#yaml) - Inserts a YAML header
+- [Metadata](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#metadata) - Inserts a yaml header
 - [Table](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#table) - Inserts a table from pipeline objects
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ PSDocs extends PowerShell with domain specific language (DSL) keywords and cmdle
 
 The following language keywords are used by the `PSDocs` module:
 
-- [Document](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Document) - Defines a named documentation block
-- [Section](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Section) - Creates a named section
-- [Title](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Title) - Sets the document title
-- [Code](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Code) - Inserts a block of code
-- [Note](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Note) - Inserts a note using DocFx formatted markdown (DFM)
-- [Warning](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Warning) - Inserts a warning using DocFx formatted markdown (DFM)
-- [Yaml](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Yaml) - Inserts a YAML header
-- [Table](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#Table) - Inserts a table from pipeline objects
+- [Document](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#document) - Defines a named documentation block
+- [Section](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#section) - Creates a named section
+- [Title](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#title) - Sets the document title
+- [Code](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#code) - Inserts a block of code
+- [Note](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#note) - Inserts a note using DocFx formatted markdown (DFM)
+- [Warning](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#warning) - Inserts a warning using DocFx formatted markdown (DFM)
+- [Yaml](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#yaml) - Inserts a YAML header
+- [Table](/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#table) - Inserts a table from pipeline objects
 
 ### Commands
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,13 @@
 version: 0.3.0.{build}
 image: Visual Studio 2017
-build: off
+
+# Only build master branch
+branches:
+  only:
+  - master
+
+build_script:
+- ps: .\scripts\build.ps1
+
 test_script:
 - ps: .\scripts\test.ps1

--- a/docs/commands/PSDocs.Dsc/en-US/Get-DscMofDocument.md
+++ b/docs/commands/PSDocs.Dsc/en-US/Get-DscMofDocument.md
@@ -52,6 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/commands/PSDocs.Dsc/en-US/Invoke-DscNodeDocument.md
+++ b/docs/commands/PSDocs.Dsc/en-US/Invoke-DscNodeDocument.md
@@ -128,6 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -16,7 +16,7 @@ Create markdown from an input object.
 ```text
 Invoke-PSDocument [-Name] <String> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
  [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
- [-PassThru] [<CommonParameters>]
+ [-PassThru] [-Option <PSDocumentOption>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -149,7 +149,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Option
+
+Additional options that configure document generation. A `PSDocumentOption` can be created by using the `New-PSDocumentOption` cmdlet. Alternatively a hashtable or path to YAML file can be specified with options.
+
+```yaml
+Type: PSDocumentOption
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/commands/PSDocs/en-US/New-PSDocumentOption.md
+++ b/docs/commands/PSDocs/en-US/New-PSDocumentOption.md
@@ -1,0 +1,86 @@
+---
+external help file: PSDocs-help.xml
+Module Name: PSDocs
+online version: https://github.com/BernieWhite/PSDocs/blob/master/docs/commands/PSDocs/en-US/New-PSDocumentOption.md
+schema: 2.0.0
+---
+
+# New-PSDocumentOption
+
+## SYNOPSIS
+
+Create options to configure document generation.
+
+## SYNTAX
+
+```text
+New-PSDocumentOption [-Option <PSDocumentOption>] [-Path <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The **New-PSDocumentOption** cmdlet creates an options object that can be passed to PSDocs cmdlets to configure document generation behaviour.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> $option = New-PSDocumentOption -Option @{ 'Markdown.WrapSeparator' = '<br />' };
+PS C:\> Invoke-PSDocument -Name 'Sample' -Option $option;
+```
+
+Create markdown using the Sample documentation definition using a wrap separator of `<br />`.
+
+## PARAMETERS
+
+### -Option
+
+Additional options that configure document generation. Option also accepts a hashtable to configure options.
+
+```yaml
+Type: PSDocumentOption
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+The path to a YAML file containing options.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: .\.psdocs.yml
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSDocs.Configuration.PSDocumentOption
+
+## NOTES
+
+## RELATED LINKS
+
+[Invoke-PSDocument]
+
+[Invoke-PSDocument]: Invoke-PSDocument.md

--- a/docs/commands/PSDocs/en-US/PSDocs.md
+++ b/docs/commands/PSDocs/en-US/PSDocs.md
@@ -29,3 +29,7 @@ Get the Yaml header from a PSDocs generated markdown file.
 ### [Invoke-PSDocument](Invoke-PSDocument.md)
 
 Create markdown from an input object.
+
+### [New-PSDocumentOption](New-PSDocumentOption.md)
+
+Create options to configure document generation.

--- a/docs/examples/Yaml-header-output.md
+++ b/docs/examples/Yaml-header-output.md
@@ -1,4 +1,6 @@
 ---
 title: An example title
+author: bewhite
+last-updated: 2018-05-17
 ---
 Yaml header may not be rendered by some markdown viewers. See source to view yaml.

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -78,6 +78,11 @@ Document 'Sample' {
 Invoke-PSDocument -Name 'Sample' -InputObject '';
 ```
 
+```markdown
+## Introduction
+This is a sample document that uses PSDocs keywords to construct a dynamic document.
+```
+
 ```powershell
 # A document definition named Sample
 Document 'Sample' {
@@ -96,6 +101,11 @@ Document 'Sample' {
 
 # Generate markdown from the document definition
 Invoke-PSDocument -Name 'Sample' -InputObject '';
+```
+
+```markdown
+## Level2
+### Level3
 ```
 
 ```powershell
@@ -117,6 +127,10 @@ Document 'Sample' {
 
 # Generate markdown from the document definition
 Invoke-PSDocument -Name 'Sample' -InputObject '';
+```
+
+```markdown
+## Included in output
 ```
 
 ### Title
@@ -202,7 +216,7 @@ Document 'CodeBlockFromPipeline' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'CodeBlockWithInfo' -InputObject $Null;
+Invoke-PSDocument -Name 'CodeBlockFromPipeline' -InputObject $Null;
 ```
 
 ### Note
@@ -231,6 +245,11 @@ Document 'NoteBlock' {
 Invoke-PSDocument -Name 'NoteBlock' -InputObject $Null;
 ```
 
+```markdown
+> [!NOTE]
+> This is a note.
+```
+
 Generates a new `NoteBlock.md` document containing a block quote formatted as a DFM note.
 
 ### Warning
@@ -256,6 +275,11 @@ Document 'WarningBlock' {
 
 # Generate markdown from the document definition
 Invoke-PSDocument -Name 'WarningBlock' -InputObject $Null;
+```
+
+```markdown
+> [!WARNING]
+> This is a warning.
 ```
 
 Generates a new `WarningBlock.md` document containing a block quote formatted as a DFM warning.
@@ -289,27 +313,43 @@ Document 'Table' {
 Invoke-PSDocument -Name 'Table';
 ```
 
+```markdown
+## Directory list
+
+|Name|PSIsContainer|
+| --- | --- |
+|Program Files|True|
+|Program Files (x86)|True|
+|Users|True|
+|Windows|True|
+```
+
 Generates a new `Table.md` document containing a table populated with a row for each item. Only the properties Name and PSIsContainer are added as columns.
 
-### Yaml
+### Metadata
 
-Creates a yaml header.
+Creates a metadata header, that will be rendered as yaml front matter. Multiple `Metadata` blocks can be used and they will be aggregated together.
 
 Syntax:
 
 ```text
-Yaml [-Body] <Hashtable>
+Metadata [-Body] <Hashtable>
 ```
 
 Examples:
 
 ```powershell
-# A document definition named YamlBlock
-Document 'YamlBlock' {
+# A document definition named MetadataBlock
+Document 'MetadataBlock' {
 
-    # Create a Yaml block of key value pairs
-    Yaml @{
+    # Create a Metadata block of key value pairs
+    Metadata @{
         title = 'An example title'
+    }
+
+    Metadata @{
+        author = $Env:USERNAME
+        'last-updated' = (Get-Date).ToString('yyyy-MM-dd')
     }
 
     # Additional text to add to the document
@@ -317,10 +357,10 @@ Document 'YamlBlock' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'YamlBlock';
+Invoke-PSDocument -Name 'MetadataBlock';
 ```
 
-Generates a new YamlBlock.md document containing a yaml header. An example of the output generated is available [here](/docs/examples/Yaml-header-output.md).
+Generates a new MetadataBlock.md document containing a yaml front matter. An example of the output generated is available [here](/docs/examples/Yaml-header-output.md).
 
 ## EXAMPLES
 

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -105,7 +105,7 @@ Document 'Sample' {
     # By default each section is included when markdown in generated
     Section 'Included in output' {
 
-        # SEction and section content is included in generated markdown
+        # Section and section content is included in generated markdown
     }
 
     # Sections can be optional if the When parameter is specified the expression evaluates to $False

--- a/docs/scenarios/Integration-with-docfx.md
+++ b/docs/scenarios/Integration-with-docfx.md
@@ -1,0 +1,53 @@
+# Integration with DocFX
+
+DocFX is a open source tool that converts markdown documentation into HTML. PSDocs can be used to dynamically generate markdown that can be processed by DocFX.
+
+DocFX uses a `docfx.json` to determine what content to include and how to process each file. To process markdown files a `build.content` section should be added to reference the output location where PSDocs will generate markdown relative to the location of `docfx.json`.
+
+An example `docfx.json` is provided below.
+
+```json
+{
+  "metadata": [
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/**.md",
+          "**/toc.yml",
+          "*.md",
+          "toc.yml"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "**/media/**"
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [ ],
+        "exclude": [
+          "out/**",
+          "build/**"
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}
+```

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -59,15 +59,15 @@ $results = RunTest -Path $testPath -SourcePath $sourcePath -OutputPath $reportsP
 
 if (![String]::IsNullOrEmpty($Env:APPVEYOR_JOB_ID)) {
     SendAppveyorTestResult -Uri "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)" -Path '.\reports' -Include '*.xml';
-}
 
-# Throw an error if pester tests failed
+    # Throw an error if pester tests failed
 
-if ($Null -eq $results) {
-    throw 'Failed to get Pester test results.';
-}
-elseif ($results.FailedCount -gt 0) {
-    throw "$($results.FailedCount) tests failed.";
+    if ($Null -eq $results) {
+        throw 'Failed to get Pester test results.';
+    }
+    elseif ($results.FailedCount -gt 0) {
+        throw "$($results.FailedCount) tests failed.";
+    }
 }
 
 Write-Verbose -Message "[Test] END::";

--- a/src/PSDocs/Configuration/MarkdownOption.cs
+++ b/src/PSDocs/Configuration/MarkdownOption.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+
+namespace PSDocs.Configuration
+{
+    public sealed class MarkdownOption
+    {
+        private const string DEFAULT_WRAP_SEPARATOR = " ";
+
+        public MarkdownOption()
+        {
+            WrapSeparator = DEFAULT_WRAP_SEPARATOR;
+        }
+
+        [DefaultValue(DEFAULT_WRAP_SEPARATOR)]
+        public string WrapSeparator { get; set; }
+    }
+}

--- a/src/PSDocs/Configuration/PSDocumentOption.cs
+++ b/src/PSDocs/Configuration/PSDocumentOption.cs
@@ -105,7 +105,7 @@ namespace PSDocs.Configuration
 
             object value;
 
-            if (index.TryGetValue("markdown.wrapseperator", out value))
+            if (index.TryGetValue("markdown.wrapseparator", out value))
             {
                 option.Markdown.WrapSeparator = (string)value;
             }

--- a/src/PSDocs/Configuration/PSDocumentOption.cs
+++ b/src/PSDocs/Configuration/PSDocumentOption.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace PSDocs.Configuration
+{
+    /// <summary>
+    /// A delgate to allow callback to PowerShell to get current working path.
+    /// </summary>
+    public delegate string GetWorkingPathDelegate();
+
+    public sealed class PSDocumentOption
+    {
+        public PSDocumentOption()
+        {
+            // Set defaults
+            Markdown = new MarkdownOption();
+        }
+
+        public PSDocumentOption(PSDocumentOption option)
+        {
+            // Set from existing option instance
+            Markdown = new MarkdownOption
+            {
+                WrapSeparator = option.Markdown.WrapSeparator
+            };
+        }
+
+        /// <summary>
+        /// A callback that is overridden by PowerShell so that the current working path can be retrieved.
+        /// </summary>
+        public static GetWorkingPathDelegate GetWorkingPath = () => Directory.GetCurrentDirectory();
+
+        /// <summary>
+        /// Options that affect markdown formatting.
+        /// </summary>
+        public MarkdownOption Markdown { get; set; }
+
+        public string ToYaml()
+        {
+            var s = new SerializerBuilder()
+                .WithNamingConvention(new CamelCaseNamingConvention())
+                .Build();
+
+            return s.Serialize(this);
+        }
+
+        public PSDocumentOption Clone()
+        {
+            return new PSDocumentOption(this);
+        }
+
+        public static PSDocumentOption FromFile(string path, bool silentlyContinue = false)
+        {
+            // Ensure that a full path instead of a path relative to PowerShell is used for .NET methods
+            var rootedPath = GetRootedPath(path);
+
+            // Fallback to defaults even if file does not exist when silentlyContinue is true
+            if (!File.Exists(rootedPath))
+            {
+                if (!silentlyContinue)
+                {
+                    throw new FileNotFoundException("", rootedPath);
+                }
+                else
+                {
+                    // Use the default options
+                    return new PSDocumentOption();
+                }
+            }
+
+            return FromYaml(File.ReadAllText(rootedPath));
+        }
+
+        public static PSDocumentOption FromYaml(string yaml)
+        {
+            var d = new DeserializerBuilder()
+                .IgnoreUnmatchedProperties()
+                .WithNamingConvention(new CamelCaseNamingConvention())
+                .Build();
+
+            return d.Deserialize<PSDocumentOption>(yaml) ?? new PSDocumentOption();
+        }
+
+        /// <summary>
+        /// Convert from hashtable to options by processing key values. This enables -Option @{ } from PowerShell.
+        /// </summary>
+        /// <param name="hashtable"></param>
+        public static implicit operator PSDocumentOption(Hashtable hashtable)
+        {
+            var option = new PSDocumentOption();
+
+            // Build index to allow mapping
+            var index = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (DictionaryEntry entry in hashtable)
+            {
+                index.Add(entry.Key.ToString(), entry.Value);
+            }
+
+            // Start loading matching values
+
+            object value;
+
+            if (index.TryGetValue("markdown.wrapseperator", out value))
+            {
+                option.Markdown.WrapSeparator = (string)value;
+            }
+
+            return option;
+        }
+
+        /// <summary>
+        /// Convert from string to options by loading the yaml file from disk. This enables -Option '.\.psdocs.yml' from PowerShell.
+        /// </summary>
+        /// <param name="path"></param>
+        public static implicit operator PSDocumentOption(string path)
+        {
+            var option = FromFile(path);
+
+            return option;
+        }
+
+        /// <summary>
+        /// Get a full path instead of a relative path that may be passed from PowerShell.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        private static string GetRootedPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : Path.Combine(GetWorkingPath(), path);
+        }
+    }
+}

--- a/src/PSDocs/Models/Code.cs
+++ b/src/PSDocs/Models/Code.cs
@@ -1,0 +1,11 @@
+﻿namespace PSDocs.Models
+{
+    public sealed class Code : DocumentNode
+    {
+        public override DocumentNodeType Type => DocumentNodeType.Code;
+
+        public string Content { get; set; }
+
+        public string Info { get; set; }
+    }
+}

--- a/src/PSDocs/Models/Document.cs
+++ b/src/PSDocs/Models/Document.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Specialized;
+
+namespace PSDocs.Models
+{
+    public sealed class Document : DocumentNode
+    {
+        public Document()
+        {
+            Title = string.Empty;
+            Metadata = new OrderedDictionary();
+        }
+
+        public override DocumentNodeType Type
+        {
+            get { return DocumentNodeType.Document; }
+        }
+
+        public string Title { get; set; }
+
+        public OrderedDictionary Metadata { get; set; }
+    }
+}

--- a/src/PSDocs/Models/DocumentNode.cs
+++ b/src/PSDocs/Models/DocumentNode.cs
@@ -1,0 +1,7 @@
+﻿namespace PSDocs.Models
+{
+    public abstract class DocumentNode
+    {
+        public abstract DocumentNodeType Type { get; }
+    }
+}

--- a/src/PSDocs/Models/DocumentNodeType.cs
+++ b/src/PSDocs/Models/DocumentNodeType.cs
@@ -6,6 +6,12 @@
 
         Section,
 
-        Table
+        Table,
+
+        Code,
+
+        Note,
+
+        Warning
     }
 }

--- a/src/PSDocs/Models/DocumentNodeType.cs
+++ b/src/PSDocs/Models/DocumentNodeType.cs
@@ -1,0 +1,11 @@
+﻿namespace PSDocs.Models
+{
+    public enum DocumentNodeType
+    {
+        Document,
+
+        Section,
+
+        Table
+    }
+}

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -2,6 +2,14 @@
 {
     public static class ModelHelper
     {
+        public static Document NewDocument()
+        {
+            return new Document
+            {
+
+            };
+        }
+
         public static Section NewSection(string name, int level)
         {
             return new Section
@@ -14,6 +22,30 @@
         public static Table NewTable()
         {
             return new Table
+            {
+
+            };
+        }
+
+        public static Code NewCode()
+        {
+            return new Code
+            {
+
+            };
+        }
+
+        public static Note NewNote()
+        {
+            return new Note
+            {
+
+            };
+        }
+
+        public static Warning NewWarning()
+        {
+            return new Warning
             {
 
             };

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -1,0 +1,22 @@
+﻿namespace PSDocs.Models
+{
+    public static class ModelHelper
+    {
+        public static Section NewSection(string name, int level)
+        {
+            return new Section
+            {
+                Content = name,
+                Level = level
+            };
+        }
+
+        public static Table NewTable()
+        {
+            return new Table
+            {
+
+            };
+        }
+    }
+}

--- a/src/PSDocs/Models/Note.cs
+++ b/src/PSDocs/Models/Note.cs
@@ -1,0 +1,9 @@
+﻿namespace PSDocs.Models
+{
+    public sealed class Note : DocumentNode
+    {
+        public override DocumentNodeType Type => DocumentNodeType.Note;
+
+        public string[] Content { get; set; }
+    }
+}

--- a/src/PSDocs/Models/Section.cs
+++ b/src/PSDocs/Models/Section.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace PSDocs.Models
+{
+    public sealed class Section : DocumentNode
+    {
+        public Section()
+        {
+            Node = new List<object>();
+        }
+
+        public override DocumentNodeType Type
+        {
+            get { return DocumentNodeType.Section; }
+        }
+
+        public string Content { get; set; }
+
+        public int Level { get; set; }
+
+        public List<object> Node { get; set; }
+    }
+}

--- a/src/PSDocs/Models/Table.cs
+++ b/src/PSDocs/Models/Table.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace PSDocs.Models
+{
+    public sealed class Table : DocumentNode
+    {
+        public Table()
+        {
+            Header = new List<string>();
+            Rows = new List<string[]>();
+        }
+
+        public override DocumentNodeType Type
+        {
+            get { return DocumentNodeType.Table; }
+        }
+
+        public IEnumerable<string[]> Rows { get; set; }
+
+        public IEnumerable<string> Header { get; set; }
+    }
+}

--- a/src/PSDocs/Models/Warning.cs
+++ b/src/PSDocs/Models/Warning.cs
@@ -1,0 +1,9 @@
+﻿namespace PSDocs.Models
+{
+    public sealed class Warning : DocumentNode
+    {
+        public override DocumentNodeType Type => DocumentNodeType.Warning;
+
+        public string[] Content { get; set; }
+    }
+}

--- a/src/PSDocs/PSDocs.csproj
+++ b/src/PSDocs/PSDocs.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="4.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/PSDocs/PSDocs.psd1
+++ b/src/PSDocs/PSDocs.psd1
@@ -70,6 +70,7 @@ FunctionsToExport = @(
     'Invoke-PSDocument'
     'Import-PSDocumentTemplate'
     'Get-PSDocumentHeader'
+    'New-PSDocumentOption'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -777,7 +777,7 @@ function ParseDom {
         $innerResult = $Dom.Node | ForEach-Object -Process {
             $node = $_;
 
-            Write-Verbose -Message "[Doc][ParseDom] -- Processing node";
+            Write-Verbose -Message "[Doc][ParseDom] -- Processing node [$nodeCounter]";
 
             if ($Null -ne $node) {
 

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -389,7 +389,7 @@ function Warning {
     }
 }
 
-function Yaml {
+function Metadata {
 
     [CmdletBinding()]
     param (
@@ -660,7 +660,8 @@ function GenerateDocument {
         $functionsToDefine['Code'] = ${function:Code};
         $functionsToDefine['Note'] = ${function:Note};
         $functionsToDefine['Warning'] = ${function:Warning};
-        $functionsToDefine['Yaml'] = ${function:Yaml};
+        $functionsToDefine['Metadata'] = ${function:Metadata};
+        $functionsToDefine['Yaml'] = ${function:Metadata};
         $functionsToDefine['Table'] = ${function:Table};
         $functionsToDefine['Format-Table'] = ${function:Table};
         $functionsToDefine['Format-List'] = ${function:FormatList};

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -228,10 +228,10 @@ function Section {
         if ($shouldProcess) {
             Write-Verbose -Message "[Doc][Section] -- Adding section: $Name";
 
+            # Create a section
             $result = [PSDocs.Models.ModelHelper]::NewSection($Name, $Section.Level+1);
 
-            # $result = New-Object -TypeName PSObject -Property @{ Content = $Name; Type = 'Section'; Node = @(); Level = ($Section.Level+1) };
-
+            # Store as section to be referenced in nested calls
             $Section = $result;
 
             try {
@@ -275,7 +275,9 @@ function Title {
 }
 
 function Code {
+
     [CmdletBinding()]
+    [OutputType([PSDocs.Models.Code])]
     param (
         # Body of the code block
         [Parameter(Position = 0, Mandatory = $True, ParameterSetName = 'Default', ValueFromPipeline = $True)]
@@ -293,7 +295,8 @@ function Code {
     )
 
     process {
-        $result = New-Object -TypeName PSObject -Property @{ Type = 'Code'; Info = ''; Content = ''; };
+
+        $result = [PSDocs.Models.ModelHelper]::NewCode();
 
         if (![String]::IsNullOrWhiteSpace($Info)) {
             $result.Info = $Info.Trim();
@@ -352,7 +355,7 @@ function Note {
 
     process {
 
-        $result = New-Object -TypeName PSObject -Property @{ Type = 'Note'; Node = @(); Content = [String[]]@(); };
+        $result = [PSDocs.Models.ModelHelper]::NewNote();
 
         $innerResult = $Body.InvokeWithContext($Null, $Null);
 
@@ -374,7 +377,7 @@ function Warning {
 
     process {
 
-        $result = New-Object -TypeName PSObject -Property @{ Type = 'Warning'; Node = @(); Content = [String[]]@(); };
+        $result = [PSDocs.Models.ModelHelper]::NewWarning();
 
         $innerResult = $Body.InvokeWithContext($Null, $Null);
 
@@ -419,9 +422,8 @@ function Table {
     begin {
         Write-Verbose -Message "[Doc][Table] BEGIN::";
 
+        # Create a table
         $table = [PSDocs.Models.ModelHelper]::NewTable();
-
-        # $table = New-Object -TypeName PSObject -Property @{ Type = 'Table'; Header = @(); Rows = (New-Object -TypeName Collections.Generic.List[String[]]); ColumnCount = 0; };
 
         $recordIndex = 0;
 
@@ -680,7 +682,7 @@ function GenerateDocument {
 
             Write-Verbose -Message "[Doc] -- Processing: $instance";
 
-            $document = New-Object -TypeName PSObject -Property @{ Type = 'Document'; Metadata = ([Ordered]@{ }); Title = [String]::Empty; };
+            $document = [PSDocs.Models.ModelHelper]::NewDocument();
 
             # Define built-in variables
             [PSVariable[]]$variablesToDefine = @(

--- a/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
+++ b/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
@@ -62,7 +62,9 @@ function VisitString {
 
 function VisitSection {
 
+    [CmdletBinding()]
     param (
+        [Parameter()]
         [PSDocs.Models.Section]$InputObject
     )
 
@@ -86,8 +88,10 @@ function VisitSection {
 
 function VisitCode { 
 
+    [CmdletBinding()]
     param (
-        $InputObject
+        [Parameter()]
+        [PSDocs.Models.Code]$InputObject
     )
 
     Write-Verbose -Message "[Doc][Processor] -- Visit code";
@@ -124,7 +128,12 @@ function VisitList {
 }
 
 function VisitNote {
-    param ($InputObject)
+
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [PSDocs.Models.Note]$InputObject
+    )
 
     Write-Verbose -Message "[Doc][Processor] -- Visit note";
     
@@ -137,7 +146,12 @@ function VisitNote {
 }
 
 function VisitWarning {
-    param ($InputObject)
+
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [PSDocs.Models.Warning]$InputObject
+    )
 
     Write-Verbose -Message "[Doc][Processor] -- Visit warning";
     
@@ -162,10 +176,12 @@ function VisitYaml {
 
     VisitString('---');
 }
-   
+
 function VisitTable {
 
+    [CmdletBinding()]
     param (
+        [Parameter()]
         [PSDocs.Models.Table]$InputObject
     )
 
@@ -197,8 +213,10 @@ function VisitTable {
 
 function VisitDocument {
 
+    [CmdletBinding()]
     param (
-        $InputObject
+        [Parameter()]
+        [PSDocs.Models.Document]$InputObject
     )
 
     if ($Null -ne $InputObject.Metadata -and $InputObject.Metadata.Count -gt 0) {

--- a/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
+++ b/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
@@ -30,7 +30,6 @@ function Visit {
         'Table' { return VisitTable($InputObject); }
         'Note' { return VisitNote($InputObject); }
         'Warning' { return VisitWarning($InputObject); }
-        'Yaml' { return VisitYaml($InputObject); }
 
         default { return VisitString($InputObject); }
     }
@@ -163,10 +162,10 @@ function VisitWarning {
     }
 }
 
-function VisitYaml {
+function VisitMetadata {
     param ($InputObject)
 
-    Write-Verbose -Message "[Doc][Processor] -- Visit yaml";
+    Write-Verbose -Message "[Doc][Processor] -- Visit metadata";
     
     VisitString('---');
 
@@ -220,7 +219,7 @@ function VisitDocument {
     )
 
     if ($Null -ne $InputObject.Metadata -and $InputObject.Metadata.Count -gt 0) {
-        VisitYaml -InputObject $InputObject;
+        VisitMetadata -InputObject $InputObject;
     }
 
     if (![String]::IsNullOrEmpty($InputObject.Title)) {

--- a/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
@@ -1,5 +1,5 @@
 #
-# Unit tests for the Yaml keyword
+# Unit tests for the Metadata keyword
 #
 
 [CmdletBinding()]
@@ -21,59 +21,59 @@ $temp = "$here\..\..\build";
 Import-Module $src -Force;
 Import-Module $src\PSDocsProcessor\Markdown -Force;
 
-$outputPath = "$temp\PSDocs.Tests\Yaml";
+$outputPath = "$temp\PSDocs.Tests\Metadata";
 New-Item $outputPath -ItemType Directory -Force | Out-Null;
 
 $dummyObject = New-Object -TypeName PSObject;
 
 $Global:TestVars = @{ };
 
-Describe 'PSDocs -- Yaml keyword' {
-    Context 'Yaml' {
+Describe 'PSDocs -- Metadata keyword' {
+    Context 'Metadata' {
 
         # Define a test document with a note
-        document 'YamlVisitor' {
+        document 'MetadataVisitor' {
             
-            Yaml @{
+            Metadata @{
                 title = 'Test'
             }
         }
 
-        Mock -CommandName 'VisitYaml' -ModuleName 'Markdown' -Verifiable -MockWith {
+        Mock -CommandName 'VisitMetadata' -ModuleName 'Markdown' -Verifiable -MockWith {
             param (
                 $InputObject
             )
 
-            $Global:TestVars['VisitYaml'] = $InputObject;
+            $Global:TestVars['VisitMetadata'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'YamlVisitor' -InputObject $dummyObject -OutputPath $outputPath;
+        Invoke-PSDocument -Name 'MetadataVisitor' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process keyword' {
-            Assert-MockCalled -CommandName 'VisitYaml' -ModuleName 'Markdown' -Times 1;
+            Assert-MockCalled -CommandName 'VisitMetadata' -ModuleName 'Markdown' -Times 1;
         }
 
         It 'Should be expected type' {
-            $Global:TestVars['VisitYaml'].Type | Should be 'Document';
+            $Global:TestVars['VisitMetadata'].Type | Should be 'Document';
         }
 
         It 'Should have expected content' {
-            $Global:TestVars['VisitYaml'].Metadata['title'] | Should be 'Test';
+            $Global:TestVars['VisitMetadata'].Metadata['title'] | Should be 'Test';
         }
     }
 
-    Context 'Yaml single entry' {
+    Context 'Metadata single entry' {
         
-        # Define a test document with yaml content
-        document 'YamlSingleEntry' {
+        # Define a test document with metadata content
+        document 'MetadataSingleEntry' {
             
-            Yaml ([ordered]@{
+            Metadata ([ordered]@{
                 title = 'Test'
             })
         }
 
-        $outputDoc = "$outputPath\YamlSingleEntry.md";
-        Invoke-PSDocument -Name 'YamlSingleEntry' -InputObject $dummyObject -OutputPath $outputPath;
+        $outputDoc = "$outputPath\MetadataSingleEntry.md";
+        Invoke-PSDocument -Name 'MetadataSingleEntry' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -84,19 +84,19 @@ Describe 'PSDocs -- Yaml keyword' {
         }
     }
 
-    Context 'Yaml multiple entries' {
+    Context 'Metadata multiple entries' {
         
-        # Define a test document with yaml content
-        document 'YamlMultipleEntry' {
+        # Define a test document with metadata content
+        document 'MetadataMultipleEntry' {
             
-            Yaml ([ordered]@{
+            Metadata ([ordered]@{
                 value1 = 'ABC'
                 value2 = 'EFG'
             })
         }
 
-        $outputDoc = "$outputPath\YamlMultipleEntry.md";
-        Invoke-PSDocument -Name 'YamlMultipleEntry' -InputObject $dummyObject -OutputPath $outputPath;
+        $outputDoc = "$outputPath\MetadataMultipleEntry.md";
+        Invoke-PSDocument -Name 'MetadataMultipleEntry' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -107,26 +107,26 @@ Describe 'PSDocs -- Yaml keyword' {
         }
     }
 
-    Context 'Yaml multiple blocks' {
+    Context 'Metadata multiple blocks' {
         
-        # Define a test document with yaml content
-        document 'YamlMultipleBlock' {
+        # Define a test document with metadata content
+        document 'MetadataMultipleBlock' {
             
-            Yaml ([ordered]@{
+            Metadata ([ordered]@{
                 value1 = 'ABC'
             })
 
             Section 'Test' {
-                'A test section spliting yaml blocks.'
+                'A test section spliting metadata blocks.'
             }
 
-            Yaml @{
+            Metadata @{
                 value2 = 'EFG'
             }
         }
 
-        $outputDoc = "$outputPath\YamlMultipleBlock.md";
-        Invoke-PSDocument -Name 'YamlMultipleBlock' -InputObject $dummyObject -OutputPath $outputPath;
+        $outputDoc = "$outputPath\MetadataMultipleBlock.md";
+        Invoke-PSDocument -Name 'MetadataMultipleBlock' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -137,18 +137,18 @@ Describe 'PSDocs -- Yaml keyword' {
         }
     }
 
-    Context 'Document without Yaml block' {
+    Context 'Document without Metadata block' {
 
-        # Define a test document without yaml content
-        document 'NoYaml' {
+        # Define a test document without metadata content
+        document 'NoMetdata' {
 
             Section 'Test' {
                 'A test section.'
             }
         }
 
-        $outputDoc = "$outputPath\NoYaml.md";
-        Invoke-PSDocument -Name 'NoYaml' -InputObject $dummyObject -OutputPath $outputPath;
+        $outputDoc = "$outputPath\NoMetdata.md";
+        Invoke-PSDocument -Name 'NoMetdata' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -159,7 +159,7 @@ Describe 'PSDocs -- Yaml keyword' {
         }
     }
 
-    Context 'Get Yaml header' {
+    Context 'Get Metadata header' {
         
         $result = Get-PSDocumentHeader -Path $outputPath;
 

--- a/tests/PSDocs.Tests/PSDocs.Table.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Table.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         It 'Should match expected format' {
-            Get-Content -Path $outputDoc -Raw | Should match '\|LICENSE\|False\|(\n|\r){1,2}\|README.md\|False\|';
+            Get-Content -Path $outputDoc -Raw | Should -Match '\|LICENSE\|False\|(\n|\r){1,2}\|README.md\|False\|';
         }
     }
 
@@ -110,11 +110,46 @@ Describe 'PSDocs -- Table keyword' {
         Invoke-PSDocument -Name 'TableWithNull' -InputObject @{ ResourceType = @{  } } -OutputPath $outputPath;
 
         It 'Should have generated output' {
-            Test-Path -Path $outputDoc | Should be $True;
+            Test-Path -Path $outputDoc | Should -Be $True;
         }
 
         It 'Should match expected format' {
-            Get-Content -Path $outputDoc -Raw | Should match '(## Windows features\r\n)$';
+            Get-Content -Path $outputDoc -Raw | Should -Match '(## Windows features\r\n)$';
+        }
+    }
+
+    Context 'Table with multiline column' {
+
+        $testObject = [PSCustomObject]@{
+            Name = 'Test'
+            Description = "This is a`r`ndescription`r`nsplit`r`nover`r`nmultiple`r`nlines."
+        }
+
+        # Define a test document with a multiple column in a table
+        document 'TableWithMultilineColumn' {
+            $testObject | Table;
+        }
+
+        $outputDoc = "$outputPath\TableWithMultilineColumn.md";
+        Invoke-PSDocument -Name 'TableWithMultilineColumn' -OutputPath $outputPath;
+
+        It 'Should have generated output' {
+            Test-Path -Path $outputDoc | Should -Be $True;
+        }
+
+        It 'Should match expected format' {
+            Get-Content -Path $outputDoc -Raw | Should -Match 'This is a description split over multiple lines\.';
+        }
+
+        $option = New-PSDocumentOption @{
+            'Markdown.WrapSeparator' = '<br />'
+        }
+
+        $outputDoc = "$outputPath\TableWithMultilineColumnCustom.md";
+        Invoke-PSDocument -Name 'TableWithMultilineColumn' -InstanceName 'TableWithMultilineColumnCustom' -OutputPath $outputPath -Option $option;
+
+        It 'Should use wrap separator' {
+            Get-Content -Path $outputDoc -Raw | Should -Match 'This is a\<br /\>description\<br /\>split\<br /\>over\<br /\>multiple\<br /\>lines\.';
         }
     }
 }


### PR DESCRIPTION
- Fix handling of line break for multiline table columns using a wrap separator 
- Added `New-PSDocumentOption` cmdlet to configure document generation 
- Added `-Option` parameter to `Invoke-PSDocument` cmdlet to accept configuration options 
- Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead

Fix #11