### PR TITLE
Added encoding support to Invoke-PSDocument issue #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 
 ## Unreleased
 
-- Fix handling of line break for multiline table columns using a wrap separator
+- Fix handling of line break for multiline table columns using a wrap separator [#11](https://github.com/BernieWhite/PSDocs/issues/11)
 - Added `New-PSDocumentOption` cmdlet to configure document generation
 - Added `-Option` parameter to `Invoke-PSDocument` cmdlet to accept configuration options
 - Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead
+- Added support for encoding markdown content output using the `-Encoding` parameter of `Invoke-PSDocument` [#16](https://github.com/BernieWhite/PSDocs/issues/16)
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 - Fix handling of line break for multiline table columns using a wrap separator [#11](https://github.com/BernieWhite/PSDocs/issues/11)
 - Added `New-PSDocumentOption` cmdlet to configure document generation
 - Added `-Option` parameter to `Invoke-PSDocument` cmdlet to accept configuration options
-- Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead
-- Added support for encoding markdown content output using the `-Encoding` parameter of `Invoke-PSDocument` [#16](https://github.com/BernieWhite/PSDocs/issues/16)
+- **Important change**: Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead
+- **Important change**: Added support for encoding markdown content output [#16](https://github.com/BernieWhite/PSDocs/issues/16)
+  - To specify the encoding use the `-Encoding` parameter of `Invoke-PSDocument`
+  - Output now defaults to UTF-8 without byte order mark (BOM) instead of ASCII
 
 ## v0.3.0
 
@@ -15,10 +17,10 @@
 - Fix to improve handling when `Title` block is used multiple times
 - Fix to prevent YAML header being created when `Yaml` block is not used
 - Code blocks now generate fenced sections instead of indented sections
-- [Breaking change] The body of Code blocks are now no longer evaluated as an expression
+- **Breaking change**: The body of Code blocks are now no longer evaluated as an expression
   - This change improves editing of document templates, allowing editors to complete valid PowerShell syntax
   - Define an expression and the pipe the results to the Code keyword to dynamically generate the contents of a code block
-- [Breaking change] `-ConfigurationData` parameter of `Invoke-PSDocument` has been removed while purpose and future use of the parameter is reconsidered
+- **Breaking change**: `-ConfigurationData` parameter of `Invoke-PSDocument` has been removed while purpose and future use of the parameter is reconsidered
 
 ## v0.2.0
 

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -16,7 +16,7 @@ Create markdown from an input object.
 ```text
 Invoke-PSDocument [-Name] <String> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
  [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
- [-PassThru] [-Option <PSDocumentOption>] [<CommonParameters>]
+ [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -161,6 +161,23 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Encoding
+
+Specifies the file encoding for generated markdown files. By default, UTF-8 without byte order mark (BOM) will be used. To use UTF-8 with BOM specify `UTF8`.
+
+```yaml
+Type: MarkdownEncoding
+Parameter Sets: (All)
+Aliases:
+Accepted values: Default, UTF8, UTF7, Unicode, UTF32, ASCII
+
+Required: False
+Position: Named
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/PSDocs/Configuration/MarkdownEncoding.cs
+++ b/src/PSDocs/Configuration/MarkdownEncoding.cs
@@ -1,0 +1,17 @@
+﻿namespace PSDocs.Configuration
+{
+    public enum MarkdownEncoding : byte
+    {
+        Default = 0,
+
+        UTF8,
+
+        UTF7,
+
+        Unicode,
+
+        UTF32,
+
+        ASCII
+    }
+}

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -15,6 +15,8 @@ else {
     return Get-Location;
 }
 
+$Script:UTF8_NO_BOM = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $False;
+
 #
 # Localization
 #
@@ -89,7 +91,10 @@ function Invoke-PSDocument {
         [Switch]$PassThru = $False,
 
         [Parameter(Mandatory = $False)]
-        [PSDocs.Configuration.PSDocumentOption]$Option
+        [PSDocs.Configuration.PSDocumentOption]$Option,
+
+        [Parameter(Mandatory = $False)]
+        [PSDocs.Configuration.MarkdownEncoding]$Encoding = [PSDocs.Configuration.MarkdownEncoding]::Default
     )
 
     process {
@@ -611,7 +616,10 @@ function GenerateDocument {
 
         [Parameter(Mandatory = $False)]
         [AllowNull()]
-        [PSDocs.Configuration.PSDocumentOption]$Option
+        [PSDocs.Configuration.PSDocumentOption]$Option,
+
+        [Parameter(Mandatory = $False)]
+        [PSDocs.Configuration.MarkdownEncoding]$Encoding = [PSDocs.Configuration.MarkdownEncoding]::Default
     )
 
     begin {
@@ -718,7 +726,7 @@ function GenerateDocument {
             }
 
             # Parse the model
-            ParseDom -Dom $dom -Processor (NewMarkdownProcessor) -Option $Option -Verbose:$VerbosePreference | WriteDocumentContent -Path $documentPath -PassThru:$PassThru;
+            ParseDom -Dom $dom -Processor (NewMarkdownProcessor) -Option $Option -Verbose:$VerbosePreference | WriteDocumentContent -Path $documentPath -PassThru:$PassThru -Encoding:$Encoding;
         }
     }
 }
@@ -735,22 +743,33 @@ function WriteDocumentContent {
         [String]$Path,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$PassThru = $False
+        [Switch]$PassThru = $False,
+
+        [Parameter(Mandatory = $False)]
+        [PSDocs.Configuration.MarkdownEncoding]$Encoding
     )
 
     begin {
-        $content = @();
+        $stringBuilder = New-Object -TypeName System.Text.StringBuilder;
+
+        $contentEncoding = $Script:UTF8_NO_BOM;
+
+        switch ($Encoding) {
+            @('UTF8', 'UTF7', 'Unicode', 'UTF32', 'ASCII') {
+                $contentEncoding = [System.Text.Encoding]::GetEncoding($Encoding);
+            }
+        }
     }
 
     process {
-        $content += $InputObject; 
+        $stringBuilder.AppendLine($InputObject);
     }
 
     end {
         if ($PassThru) {
-            $content;
+            $stringBuilder.ToString();
         } else {
-            $content | Set-Content -Path $Path;
+            [System.IO.File]::WriteAllText($Path, $stringBuilder.ToString(), $contentEncoding);
         }
         
     }

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -755,9 +755,11 @@ function WriteDocumentContent {
         $contentEncoding = $Script:UTF8_NO_BOM;
 
         switch ($Encoding) {
-            @('UTF8', 'UTF7', 'Unicode', 'UTF32', 'ASCII') {
-                $contentEncoding = [System.Text.Encoding]::GetEncoding($Encoding);
-            }
+            'UTF8' { $contentEncoding = [System.Text.Encoding]::GetEncoding('UTF-8'); break; }
+            'UTF7' { $contentEncoding = [System.Text.Encoding]::GetEncoding('UTF-7'); break; }
+            'Unicode' { $contentEncoding = [System.Text.Encoding]::GetEncoding('Unicode'); break; }
+            'UTF32' { $contentEncoding = [System.Text.Encoding]::GetEncoding('UTF-32'); break; }
+            'ASCII' { $contentEncoding = [System.Text.Encoding]::GetEncoding('ASCII'); break; }
         }
     }
 

--- a/tests/PSDocs.Dsc.Tests/PSDocs.Dsc.Common.Tests.ps1
+++ b/tests/PSDocs.Dsc.Tests/PSDocs.Dsc.Common.Tests.ps1
@@ -17,8 +17,8 @@ $src = ($here -replace '\\tests\\', '\\src\\') -replace '\.Tests', '';
 $temp = "$here\..\..\build";
 # $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.';
 
-Import-Module $src -Force;
 Import-Module $src\..\PSDocs -Force;
+Import-Module $src -Force;
 
 $outputPath = "$temp\PSDocs.Dsc.Tests\Common";
 Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction SilentlyContinue;

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -99,4 +99,20 @@ Describe 'PSDocs' {
             Get-Content -Path "$outputPath\Instance3.md" -Raw | Should match 'Instance3';
         }
     }
+
+    Context 'Generate a document with a specific encoding' {
+
+        document 'WithEncoding' {
+            $InstanceName;
+        }
+
+        # Check each encoding can be written then read
+        foreach ($encoding in @('UTF8', 'UTF7', 'Unicode', 'ASCII')) {
+
+            It "Should generate $encoding encoded content" {
+                Invoke-PSDocument -Name 'WithEncoding' -InstanceName "With$encoding" -InputObject $dummyObject -OutputPath $outputPath -Encoding $encoding;
+                Get-Content -Path (Join-Path -Path $outputPath -ChildPath "With$encoding.md") -Raw -Encoding $encoding | Should -BeExactly "With$encoding`r`n";
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added support for encoding markdown content output [#16](https://github.com/BernieWhite/PSDocs/issues/16)

- To specify the encoding use the `-Encoding` parameter of `Invoke-PSDocument`
- Output now defaults to UTF-8 without byte order mark (BOM) instead of ASCII

Fix #16