### PR TITLE
Devops processing issue #25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 
 - Fix to prevent string builder properties being outputted each time `Invoke-PSDocument` is called
-- Added support for property expressions with the `Table` keyword
+- Added support for property expressions with the `Table` keyword [#27](https://github.com/BernieWhite/PSDocs/issues/27)
 - **Important change**: Deprecated support for using `Invoke-PSDocument` with inline document definitions
   - Improved support for using named document definitions inline, this is the recommended way to call inline document definitions
 - Added support for building all document definitions from a path using the `-Path` parameter [#25](https://github.com/BernieWhite/PSDocs/issues/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 - Fix to prevent string builder properties being outputted each time `Invoke-PSDocument` is called
 - Added support for property expressions with the `Table` keyword
+- **Important change**: Deprecated support for using `Invoke-PSDocument` with inline document definitions
+  - Improved support for using named document definitions inline, this is the recommended way to call inline document definitions
+- Added support for building all document definitions from a path using the `-Path` parameter [#25](https://github.com/BernieWhite/PSDocs/issues/25)
+  - Additionally document definitions can be filtered with the `-Name` and `-Tag` parameter
+  - This is the recommended way to build documents going forward
 
 ## v0.4.0
 

--- a/PSDocs.build.ps1
+++ b/PSDocs.build.ps1
@@ -11,7 +11,7 @@ param (
 )
 
 # Copy the PowerShell modules files to the destination path
-function CopyModule {
+function CopyModuleFiles {
 
     param (
         [Parameter(Mandatory = $True)]
@@ -83,17 +83,20 @@ function SendAppveyorTestResult {
     }
 }
 
-# Synopsis: Build modules only
-task BuildModule {
-
+task BuildDotNet {
     exec {
         # Build library
         dotnet publish src/PSDocs -c Release -f net451 -o $(Join-Path -Path $PWD -ChildPath out/modules/PSDocs/bin/net451)
     }
-
-    CopyModule -Path src/PSDocs -DestinationPath out/modules/PSDocs;
-    CopyModule -Path src/PSDocs.Dsc -DestinationPath out/modules/PSDocs.Dsc;
 }
+
+task CopyModule {
+    CopyModuleFiles -Path src/PSDocs -DestinationPath out/modules/PSDocs;
+    CopyModuleFiles -Path src/PSDocs.Dsc -DestinationPath out/modules/PSDocs.Dsc;
+}
+
+# Synopsis: Build modules only
+task BuildModule BuildDotNet, CopyModule
 
 # Synopsis: Build help
 task BuildHelp BuildModule, PlatyPS, {

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Document Sample {
     }
 }
 
-# Call the document definition and generate markdown from an object
-Invoke-PSDocument -Name 'Sample' -InputObject 'C:\';
+# Call the document definition as a function to generate markdown from an object
+Sample -InputObject 'C:\';
 ```
 
 An example of the output generated is available [here](/docs/examples/Get-child-item-output.md).

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -13,8 +13,17 @@ Create markdown from an input object.
 
 ## SYNTAX
 
-```text
-Invoke-PSDocument [-Name] <String> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
+### Inline (Default)
+```
+Invoke-PSDocument -Name <String[]> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
+ [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
+ [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
+```
+
+### Path
+```
+Invoke-PSDocument [-Name <String[]>] [-Tag <String[]>] [-InstanceName <String[]>] [-InputObject <PSObject>]
+ [-Path] <String> [-OutputPath <String>]
  [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
  [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
 ```
@@ -114,12 +123,24 @@ Accept wildcard characters: False
 The name of a specific document template to use to generate markdown.
 
 ```yaml
-Type: String
-Parameter Sets: (All)
+Type: String[]
+Parameter Sets: Inline
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -186,6 +207,38 @@ Accepted values: Default, UTF8, UTF7, Unicode, UTF32, ASCII
 Required: False
 Position: Named
 Default value: Default
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+A directory path to read document definitions recursively from. Document definitions are discovered within files ending in `.doc.ps1`.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+
+One or more tags that the document definition must contain. If more then one tag is specified, all tags be present on the document definition to be evaluated.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -45,7 +45,15 @@ Document Sample {
 Invoke-PSDocument -Name 'Sample' -InputObject 'C:\';
 ```
 
-Create markdown using the Sample documentation definition for 'C:\'.
+Create markdown using the inline documentation definition called Sample using as input 'C:\'.
+
+### Example 2
+
+```powershell
+Invoke-PSDocument -Path .;
+```
+
+Create markdown using *.doc.ps1 files loaded from the current working directory.
 
 ## PARAMETERS
 

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -14,14 +14,16 @@ Create markdown from an input object.
 ## SYNTAX
 
 ### Inline (Default)
-```
+
+```text
 Invoke-PSDocument -Name <String[]> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
  [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
  [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
 ```
 
 ### Path
-```
+
+```text
 Invoke-PSDocument [-Name <String[]>] [-Tag <String[]>] [-InstanceName <String[]>] [-InputObject <PSObject>]
  [-Path] <String> [-OutputPath <String>]
  [-Function <System.Collections.Generic.Dictionary`2[System.String,System.Management.Automation.ScriptBlock]>]
@@ -37,7 +39,32 @@ Create markdown from an input object using a document definition. A document is 
 ### Example 1
 
 ```powershell
-# Define a document called Sample
+# Create a new document definition called Sample in sample.doc.ps1
+Set-Content -Path .\sample.doc.ps1 -Value @'
+Document Sample {
+
+    # Add an introduction section
+    Section Introduction {
+
+        # Add a comment
+        "This is a sample file list from $InputObject"
+
+        # Generate a table
+        Get-ChildItem -Path $InputObject | Table -Property Name,PSIsContainer
+    }
+}
+'@
+
+# Discover document definitions in the current working path (and subdirectories) within .doc.ps1 files
+Invoke-PSDocument -Path .;
+```
+
+Create markdown using *.doc.ps1 files loaded from the current working directory.
+
+### Example 2
+
+```powershell
+# Define an inline document called Sample
 Document Sample {
 
     # Add an introduction section
@@ -51,18 +78,14 @@ Document Sample {
     }
 }
 
+# Calling an inline document definition by name using Invoke-PSDocument is depricated
 Invoke-PSDocument -Name 'Sample' -InputObject 'C:\';
+
+# This is recommended way to call Sample
+Sample -InputObject 'C:\';
 ```
 
 Create markdown using the inline documentation definition called Sample using as input 'C:\'.
-
-### Example 2
-
-```powershell
-Invoke-PSDocument -Path .;
-```
-
-Create markdown using *.doc.ps1 files loaded from the current working directory.
 
 ## PARAMETERS
 

--- a/src/PSDocs.Dsc/PSDocs.Dsc.psm1
+++ b/src/PSDocs.Dsc/PSDocs.Dsc.psm1
@@ -152,7 +152,6 @@ function BuildDocumentation {
         }
 
         $docParams = @{
-            Name = $DocumentName
             OutputPath = $OutputPath
         };
 
@@ -166,7 +165,7 @@ function BuildDocumentation {
             # Write-Verbose -Message "[Doc] -- Generating documentation: $OutputPath";
 
             # Generate a document for the configuration
-            Invoke-PSDocument -InputObject $r -InstanceName $r.InstanceName @docParams -Verbose:$VerbosePreference;
+            [ScriptBlock]::Create("$DocumentName" + ' -InputObject $r -InstanceName $r.InstanceName @docParams -Verbose:$VerbosePreference; ').Invoke();
         }
 
         # Write-Verbose -Message "[Doc][$dokOperation] -- Update TOC: $($buildResult.FullName)";

--- a/src/PSDocs/Models/Document.cs
+++ b/src/PSDocs/Models/Document.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace PSDocs.Models
 {
@@ -8,6 +9,8 @@ namespace PSDocs.Models
         {
             Title = string.Empty;
             Metadata = new OrderedDictionary();
+            Path = null;
+            Node = new List<object>();
         }
 
         public override DocumentNodeType Type
@@ -18,5 +21,9 @@ namespace PSDocs.Models
         public string Title { get; set; }
 
         public OrderedDictionary Metadata { get; set; }
+
+        public string Path { get; set; }
+
+        public List<object> Node { get; set; }
     }
 }

--- a/src/PSDocs/Models/PSDocsHelper.cs
+++ b/src/PSDocs/Models/PSDocsHelper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PSDocs.Models
+{
+    public static class PSDocsHelper
+    {
+        /// <summary>
+        /// Check if the defined tags match the expected tags.
+        /// </summary>
+        /// <param name="definitionTags">The tags of the document definition.</param>
+        /// <param name="match">The tags to match.</param>
+        /// <returns>Returns true when all the matching tags are found on the document definition.</returns>
+        public static bool MatchTags(string[] definitionTags, string[] match)
+        {
+            if (match == null || match.Length == 0)
+            {
+                return true;
+            }
+
+            if (definitionTags == null || definitionTags.Length < match.Length)
+            {
+                return false;
+            }
+
+            var tags = new HashSet<string>(definitionTags, StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (var m in match)
+            {
+                if (!tags.Contains(m))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -61,7 +61,9 @@ function Document {
         else {
             Write-Verbose -Message "[Doc] -- Calling document block: $Name";
 
-            if (($Null -eq $PSDocs.Context.Name -or $Name -in $PSDocs.Context.Name) -and ($Null -eq $PSDocs.Context.Tag -or $Tag -in $PSDocs.Context.Tag)) {
+            $matchTags = [PSDocs.Models.PSDocsHelper]::MatchTags($Tag, $PSDocs.Context.Tag);
+
+            if (($Null -eq $PSDocs.Context.Name -or $Name -in $PSDocs.Context.Name) -and $matchTags) {
 
                 [String[]]$instances = @($InstanceName);
 

--- a/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
+++ b/src/PSDocs/PSDocsProcessor/Markdown/Markdown.psm1
@@ -7,7 +7,7 @@ function Visit {
     [CmdletBinding()]
     param (
         [Parameter()]
-        $InputObject,
+        [Object]$InputObject,
 
         [Parameter()]
         [PSDocs.Configuration.PSDocumentOption]$Option
@@ -87,7 +87,7 @@ function VisitSection {
     foreach ($n in $section.Node) {
 
         # Visit each node within the section
-        Visit($n);
+        Visit -InputObject $n -Option $Option;
     }
 
     Write-Verbose -Message "[Doc][Processor][Section] END:: [$($section.Node.Length)]";
@@ -228,11 +228,19 @@ function VisitDocument {
         [PSDocs.Models.Document]$InputObject
     )
 
-    if ($Null -ne $InputObject.Metadata -and $InputObject.Metadata.Count -gt 0) {
-        VisitMetadata -InputObject $InputObject;
+    $document = $InputObject;
+
+    if ($Null -ne $document.Metadata -and $document.Metadata.Count -gt 0) {
+        VisitMetadata -InputObject $document;
     }
 
-    if (![String]::IsNullOrEmpty($InputObject.Title)) {
-        VisitTitle -InputObject $InputObject;
+    if (![String]::IsNullOrEmpty($document.Title)) {
+        VisitTitle -InputObject $document;
+    }
+
+    foreach ($n in $document.Node) {
+
+        # Visit each node within the document
+        Visit -InputObject $n -Option $Option;
     }
 }

--- a/src/PSDocs/en-AU/PSDocs.Resources.psd1
+++ b/src/PSDocs/en-AU/PSDocs.Resources.psd1
@@ -2,6 +2,7 @@
 ConvertFrom-StringData @'
 ###PSLOC
 DocumentNotFound=Failed to find document: {0}
+PathNotFound=Path not found
 DocumentProcessFailure=Failed to process document
 SectionProcessFailure=Failed to process section: {0}
 ###PSLOC

--- a/src/PSDocs/en-US/PSDocs.Resources.psd1
+++ b/src/PSDocs/en-US/PSDocs.Resources.psd1
@@ -2,6 +2,7 @@
 ConvertFrom-StringData @'
 ###PSLOC
 DocumentNotFound=Failed to find document: {0}
+PathNotFound=Path not found
 DocumentProcessFailure=Failed to process document
 SectionProcessFailure=Failed to process section: {0}
 ###PSLOC

--- a/tests/PSDocs.Tests/FromFile.doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.doc.ps1
@@ -1,0 +1,10 @@
+
+document 'FromFileTest1' {
+
+    'Test 1'
+}
+
+document 'FromFileTest2' {
+
+    'Test 2'
+}

--- a/tests/PSDocs.Tests/FromFile.doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.doc.ps1
@@ -19,3 +19,17 @@ document 'FromFileTest3' -Tag 'Test3' {
         'Test 3'
     }
 }
+
+document 'FromFileTest4' -Tag 'Test4' {
+    
+    Section 'Test' {
+        'Test 4'
+    }
+}
+
+document 'FromFileTest5' -Tag 'Test4','Test5' {
+    
+    Section 'Test' {
+        'Test 5'
+    }
+}

--- a/tests/PSDocs.Tests/FromFile.doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.doc.ps1
@@ -1,10 +1,21 @@
 
 document 'FromFileTest1' {
 
-    'Test 1'
+    Section 'Test' {
+        'Test 1'
+    }
 }
 
 document 'FromFileTest2' {
 
-    'Test 2'
+    Section 'Test' {
+        'Test 2'
+    }
+}
+
+document 'FromFileTest3' -Tag 'Test3' {
+
+    Section 'Test' {
+        'Test 3'
+    }
 }

--- a/tests/PSDocs.Tests/PSDocs.Code.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Code.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'PSDocs -- Code keyword' {
             $Global:TestVars['VisitCode'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'CodeTests' -InstanceName 'Code' -InputObject $dummyObject -OutputPath $outputPath;
+        CodeTests -InstanceName 'Code' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process Code keyword' {
             Assert-MockCalled -CommandName 'VisitCode' -ModuleName 'Markdown' -Times 1;
@@ -71,7 +71,7 @@ Describe 'PSDocs -- Code keyword' {
         }
 
         $outputDoc = "$outputPath\CodeMarkdown.md";
-        Invoke-PSDocument -Name 'CodeMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        CodeMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -93,7 +93,7 @@ Describe 'PSDocs -- Code keyword' {
         }
 
         $outputDoc = "$outputPath\CodeMarkdownNamedFormat.md";
-        Invoke-PSDocument -Name 'CodeMarkdownNamedFormat' -InputObject $dummyObject -OutputPath $outputPath;
+        CodeMarkdownNamedFormat -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -113,7 +113,7 @@ Describe 'PSDocs -- Code keyword' {
         }
 
         $outputDoc = "$outputPath\CodeMarkdownEval.md";
-        Invoke-PSDocument -Name 'CodeMarkdownEval' -InputObject $dummyObject -OutputPath $outputPath;
+        CodeMarkdownEval -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -153,5 +153,13 @@ Describe 'Invoke-PSDocument' -Tag 'FromPath' {
             Test-Path -Path "$outputPath\FromFileTest1.md" | Should be $False;
             Test-Path -Path "$outputPath\FromFileTest3.md" | Should be $True;
         }
+
+        Invoke-PSDocument -Path $here -OutputPath $outputPath -Tag 'Test4','Test5' -Verbose;
+
+        It 'Should generate tagged documents' {
+            Test-Path -Path "$outputPath\FromFileTest1.md" | Should be $False;
+            Test-Path -Path "$outputPath\FromFileTest4.md" | Should be $False;
+            Test-Path -Path "$outputPath\FromFileTest5.md" | Should be $True;
+        }
     }
 }

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -37,7 +37,7 @@ $dummyObject = New-Object -TypeName PSObject -Property @{
 
 $Global:TestVars = @{ };
 
-Describe 'PSDocs' {
+Describe 'PSDocs instance names' {
     Context 'Generate a document without an instance name' {
 
         # Define a test document with a table
@@ -50,7 +50,7 @@ Describe 'PSDocs' {
         }
 
         $outputDoc = "$outputPath\WithoutInstanceName.md";
-        Invoke-PSDocument -Name 'WithoutInstanceName' -InputObject $dummyObject -OutputPath $outputPath;
+        WithoutInstanceName -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should generate an output named WithoutInstanceName.md' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -73,7 +73,7 @@ Describe 'PSDocs' {
             $InstanceName;
         }
 
-        Invoke-PSDocument -Name 'WithInstanceName' -InstanceName 'Instance1' -InputObject $dummyObject -OutputPath $outputPath;
+        WithInstanceName -InstanceName 'Instance1' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should not create a output with the document name' {
             Test-Path -Path "$outputPath\WithInstanceName.md" | Should be $False;
@@ -95,7 +95,7 @@ Describe 'PSDocs' {
             $InstanceName;
         }
 
-        Invoke-PSDocument -Name 'WithMultiInstanceName' -InstanceName 'Instance2','Instance3' -InputObject $dummyObject -OutputPath $outputPath;
+        WithMultiInstanceName -InstanceName 'Instance2','Instance3' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should not create a output with the document name' {
             Test-Path -Path "$outputPath\WithMultiInstanceName.md" | Should be $False;
@@ -128,9 +128,30 @@ Describe 'PSDocs' {
         foreach ($encoding in @('UTF8', 'UTF7', 'Unicode', 'ASCII', 'UTF32')) {
 
             It "Should generate $encoding encoded content" {
-                Invoke-PSDocument -Name 'WithEncoding' -InstanceName "With$encoding" -InputObject $dummyObject -OutputPath $outputPath -Encoding $encoding;
+                WithEncoding -InstanceName "With$encoding" -InputObject $dummyObject -OutputPath $outputPath -Encoding $encoding;
                 Get-Content -Path (Join-Path -Path $outputPath -ChildPath "With$encoding.md") -Raw -Encoding $encoding | Should -BeExactly "With$encoding`r`n";
             }
+        }
+    }
+}
+
+Describe 'Invoke-PSDocument' -Tag 'FromPath' {
+    Context 'With -Path' {
+
+        # Only generate documents for the named document
+        Invoke-PSDocument -Path $here -OutputPath $outputPath -Name 'FromFileTest2' -Verbose;
+
+        It 'Should generate named documents' {
+            Test-Path -Path "$outputPath\FromFileTest1.md" | Should be $False;
+            Test-Path -Path "$outputPath\FromFileTest2.md" | Should be $True;
+            Test-Path -Path "$outputPath\FromFileTest3.md" | Should be $False;
+        }
+
+        Invoke-PSDocument -Path $here -OutputPath $outputPath -Tag 'Test3' -Verbose;
+
+        It 'Should generate tagged documents' {
+            Test-Path -Path "$outputPath\FromFileTest1.md" | Should be $False;
+            Test-Path -Path "$outputPath\FromFileTest3.md" | Should be $True;
         }
     }
 }

--- a/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'PSDocs -- Metadata keyword' {
             $Global:TestVars['VisitMetadata'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'MetadataVisitor' -InputObject $dummyObject -OutputPath $outputPath;
+        MetadataVisitor -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process keyword' {
             Assert-MockCalled -CommandName 'VisitMetadata' -ModuleName 'Markdown' -Times 1;
@@ -71,7 +71,7 @@ Describe 'PSDocs -- Metadata keyword' {
         }
 
         $outputDoc = "$outputPath\MetadataSingleEntry.md";
-        Invoke-PSDocument -Name 'MetadataSingleEntry' -InputObject $dummyObject -OutputPath $outputPath;
+        MetadataSingleEntry -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -94,7 +94,7 @@ Describe 'PSDocs -- Metadata keyword' {
         }
 
         $outputDoc = "$outputPath\MetadataMultipleEntry.md";
-        Invoke-PSDocument -Name 'MetadataMultipleEntry' -InputObject $dummyObject -OutputPath $outputPath;
+        MetadataMultipleEntry -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -124,7 +124,7 @@ Describe 'PSDocs -- Metadata keyword' {
         }
 
         $outputDoc = "$outputPath\MetadataMultipleBlock.md";
-        Invoke-PSDocument -Name 'MetadataMultipleBlock' -InputObject $dummyObject -OutputPath $outputPath;
+        MetadataMultipleBlock -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -146,7 +146,7 @@ Describe 'PSDocs -- Metadata keyword' {
         }
 
         $outputDoc = "$outputPath\NoMetdata.md";
-        Invoke-PSDocument -Name 'NoMetdata' -InputObject $dummyObject -OutputPath $outputPath;
+        NoMetdata -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;

--- a/tests/PSDocs.Tests/PSDocs.Note.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Note.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'PSDocs -- Note keyword' {
             $Global:TestVars['VisitNote'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'NoteVisitor' -InputObject $dummyObject -OutputPath $outputPath;
+        NoteVisitor -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process Note keyword' {
             Assert-MockCalled -CommandName 'VisitNote' -ModuleName 'Markdown' -Times 1;
@@ -71,7 +71,7 @@ Describe 'PSDocs -- Note keyword' {
         }
 
         $outputDoc = "$outputPath\NoteSingleMarkdown.md";
-        Invoke-PSDocument -Name 'NoteSingleMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        NoteSingleMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -94,7 +94,7 @@ Describe 'PSDocs -- Note keyword' {
         }
 
         $outputDoc = "$outputPath\NoteMultiMarkdown.md";
-        Invoke-PSDocument -Name 'NoteMultiMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        NoteMultiMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;

--- a/tests/PSDocs.Tests/PSDocs.Section.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Section.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'PSDocs -- Section keyword' {
             $Global:TestVars['VisitSection'] = $InputObject;
         }
 
-        $result = Invoke-PSDocument -Name 'SectionBlockTests' -InstanceName 'Section' -InputObject $dummyObject -OutputPath $outputPath -PassThru;
+        $result = SectionBlockTests -InstanceName 'Section' -InputObject $dummyObject -OutputPath $outputPath -PassThru;
 
         It 'Should process Section keyword' {
             Assert-MockCalled -CommandName 'VisitSection' -ModuleName 'Markdown' -Times 1;
@@ -77,7 +77,7 @@ Describe 'PSDocs -- Section keyword' {
         }
 
         $outputDoc = "$outputPath\Section.md";
-        Invoke-PSDocument -Name 'SectionBlockTests' -InstanceName 'Section' -InputObject $dummyObject -OutputPath $outputPath;
+        SectionBlockTests -InstanceName 'Section' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -102,7 +102,7 @@ Describe 'PSDocs -- Section keyword' {
         }
 
         $outputDoc = "$outputPath\SectionWhen.md";
-        Invoke-PSDocument -Name 'SectionWhen' -InputObject $dummyObject -OutputPath $outputPath;
+        SectionWhen -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;

--- a/tests/PSDocs.Tests/PSDocs.Table.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Table.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'PSDocs -- Table keyword' {
             $Global:TestVars['VisitTable'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'WithSingleNamedProperty' -InputObject $dummyObject -OutputPath $outputPath;
+        WithSingleNamedProperty -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process Table keyword' {
             Assert-MockCalled -CommandName 'VisitTable' -ModuleName 'Markdown' -Times 1;
@@ -64,7 +64,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\Table.md";
-        Invoke-PSDocument -Name 'TableTests' -InstanceName 'Table' -InputObject $dummyObject -OutputPath $outputPath;
+        TableTests -InstanceName 'Table' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -94,7 +94,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\TableWithExpression.md";
-        Invoke-PSDocument -Name 'TableWithExpression' -OutputPath $outputPath -Verbose
+        TableWithExpression -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -114,7 +114,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\TableSingleEntryMarkdown.md";
-        Invoke-PSDocument -Name 'TableSingleEntryMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        TableSingleEntryMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -137,7 +137,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\TableWithNull.md";
-        Invoke-PSDocument -Name 'TableWithNull' -InputObject @{ ResourceType = @{  } } -OutputPath $outputPath;
+        TableWithNull -InputObject @{ ResourceType = @{  } } -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should -Be $True;
@@ -161,7 +161,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\TableWithMultilineColumn.md";
-        Invoke-PSDocument -Name 'TableWithMultilineColumn' -OutputPath $outputPath;
+        TableWithMultilineColumn -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should -Be $True;
@@ -176,7 +176,7 @@ Describe 'PSDocs -- Table keyword' {
         }
 
         $outputDoc = "$outputPath\TableWithMultilineColumnCustom.md";
-        Invoke-PSDocument -Name 'TableWithMultilineColumn' -InstanceName 'TableWithMultilineColumnCustom' -OutputPath $outputPath -Option $option;
+        TableWithMultilineColumn -InstanceName 'TableWithMultilineColumnCustom' -OutputPath $outputPath -Option $option;
 
         It 'Should use wrap separator' {
             Get-Content -Path $outputDoc -Raw | Should -Match 'This is a\<br /\>description\<br /\>split\<br /\>over\<br /\>multiple\<br /\>lines\.';

--- a/tests/PSDocs.Tests/PSDocs.Title.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Title.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'PSDocs -- Title keyword' {
             $Global:TestVars['VisitTitle'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'VisitTitle' -InstanceName 'VisitTitle' -InputObject $dummyObject -OutputPath $outputPath;
+        VisitTitle -InstanceName 'VisitTitle' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process Title keyword' {
             Assert-MockCalled -CommandName 'VisitTitle' -ModuleName 'Markdown' -Times 1;
@@ -67,7 +67,7 @@ Describe 'PSDocs -- Title keyword' {
         }
 
         $outputDoc = "$outputPath\SingleTitle.md";
-        Invoke-PSDocument -Name 'SingleTitle' -InputObject $dummyObject -OutputPath $outputPath;
+        SingleTitle -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -89,7 +89,7 @@ Describe 'PSDocs -- Title keyword' {
         }
 
         $outputDoc = "$outputPath\MultipleTitle.md";
-        Invoke-PSDocument -Name 'MultipleTitle' -InputObject $dummyObject -OutputPath $outputPath;
+        MultipleTitle -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;

--- a/tests/PSDocs.Tests/PSDocs.Warning.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Warning.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'PSDocs -- Warning keyword' {
             $Global:TestVars['VisitWarning'] = $InputObject;
         }
 
-        Invoke-PSDocument -Name 'WarningVisitor' -InputObject $dummyObject -OutputPath $outputPath;
+        WarningVisitor -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should process keyword' {
             Assert-MockCalled -CommandName 'VisitWarning' -ModuleName 'Markdown' -Times 1;
@@ -71,7 +71,7 @@ Describe 'PSDocs -- Warning keyword' {
         }
 
         $outputDoc = "$outputPath\WarningSingleMarkdown.md";
-        Invoke-PSDocument -Name 'WarningSingleMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        WarningSingleMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;
@@ -94,7 +94,7 @@ Describe 'PSDocs -- Warning keyword' {
         }
 
         $outputDoc = "$outputPath\WarningMultiMarkdown.md";
-        Invoke-PSDocument -Name 'WarningMultiMarkdown' -InputObject $dummyObject -OutputPath $outputPath;
+        WarningMultiMarkdown -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
             Test-Path -Path $outputDoc | Should be $True;


### PR DESCRIPTION
- **Important change**: Deprecated support for using `Invoke-PSDocument` with inline document definitions
  - Improved support for using named document definitions inline, this is the recommended way to call inline document definitions
- Added support for building all document definitions from a path using the `-Path` parameter [#25](https://github.com/BernieWhite/PSDocs/issues/25)
  - Additionally document definitions can be filtered with the `-Name` and `-Tag` parameter
  - This is the recommended way to build documents going forward