### PR TITLE
Avoid generating empty section blocks #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Additionally document definitions can be filtered with the `-Name` and `-Tag` parameter
   - This is the recommended way to build documents going forward
 - Added support for providing options for `Invoke-PSDocument` using YAML, see `about_PSDocs_Options`
+- **Breaking change**: Empty `Section` blocks are not rendered by default [#32](https://github.com/BernieWhite/PSDocs/issues/32)
+  - Use `-Force` parameter on specific sections or `Markdown.SkipEmptySections = $False` option to force the empty sections to written
 
 ## v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following conceptual topics exist in the `PSDocs` module:
 - [Options](/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md)
   - [Markdown.WrapSeparator](/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#wrap-separator)
   - [Markdown.Encoding](/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#encoding)
+  - [Markdown.SkipEmptySections](/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#skip-empty-sections)
 
 ## Changes and versioning
 

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md
@@ -94,14 +94,49 @@ markdown:
 
 Additionally `Invoke-PSDocument` has a `-Encoding` parameter. When the `-Encoding` parameter is used, it always takes precedence over an encoding set through `-Option` or `psdocs.yml`.
 
+Prior to PSDocs v0.4.0 the only encoding supported was ASCII.
+
+### Skip empty sections
+
+From PSDocs v0.5.0 onward, `Section` blocks that are empty are omitted from markdown output by default. i.e. `Markdown.SkipEmptySections` is `$True`.
+
+To include empty sections (PSDocs v0.4.0 or older) in markdown output either use the `-Force` parameter on a specific `Section` block or set `Markdown.SkipEmptySections = $False`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the Markdown.SkipEmptySections hash table key
+$option = New-PSDocumentOption -Option @{ 'Markdown.SkipEmptySections' = $False }
+```
+
+```yaml
+# psdocs.yml: Using the markdown/skipEmptySections YAML property
+markdown:
+  skipEmptySections: false
+```
+
 ## EXAMPLES
+
+### Example PSDocs.yml
 
 ```yaml
 # Set markdown options
 markdown:
   # Use UTF-8 with BOM
   encoding: UTF8
+  skipEmptySections: false
   wrapSeparator: '\'
+```
+
+### Default PSDocs.yml
+
+```yaml
+# These are the default options.
+# Only properties that differ from the default values need to be specified.
+markdown:
+  encoding: Default
+  skipEmptySections: true
+  wrapSeparator: ' '
 ```
 
 ## NOTE

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -42,7 +42,7 @@ Document 'Sample' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'Sample' -InputObject '';
+Sample -InputObject '';
 ```
 
 ### Section
@@ -52,11 +52,12 @@ Creates a new document section block containing content. Each section will be co
 Syntax:
 
 ```text
-Section [-Name] <String> [-When <ScriptBlock>] [-Body] <ScriptBlock>
+Section [-Name] <String> [-When <ScriptBlock>] [-Force] [-Body] <ScriptBlock>
 ```
 
 - `Name` - The name or header of the section.
 - `When` - A condition to determine if the section block should be included in the markdown document.
+- `Force` - Force the creation of the section even if the section has not content.
 
 Examples:
 
@@ -75,7 +76,7 @@ Document 'Sample' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'Sample' -InputObject '';
+Sample -InputObject '';
 ```
 
 ```markdown
@@ -90,7 +91,7 @@ Document 'Sample' {
     # Sections can be nested
     Section 'Level2' {
 
-        Section 'Level3' {
+        Section 'Level3' -Force {
 
             # Define level 3 section content here
         }
@@ -100,7 +101,7 @@ Document 'Sample' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'Sample' -InputObject '';
+Sample -InputObject '';
 ```
 
 ```markdown
@@ -113,7 +114,7 @@ Invoke-PSDocument -Name 'Sample' -InputObject '';
 Document 'Sample' {
 
     # By default each section is included when markdown in generated
-    Section 'Included in output' {
+    Section 'Included in output' -Force {
 
         # Section and section content is included in generated markdown
     }
@@ -126,7 +127,7 @@ Document 'Sample' {
 }
 
 # Generate markdown from the document definition
-Invoke-PSDocument -Name 'Sample' -InputObject '';
+Sample -InputObject '';
 ```
 
 ```markdown

--- a/src/PSDocs/Configuration/MarkdownOption.cs
+++ b/src/PSDocs/Configuration/MarkdownOption.cs
@@ -9,10 +9,13 @@ namespace PSDocs.Configuration
 
         private const MarkdownEncoding DEFAULT_ENCODING = MarkdownEncoding.Default;
 
+        private const bool DEFAULT_SKIP_EMPTY_SECTIONS = true;
+
         public MarkdownOption()
         {
             WrapSeparator = DEFAULT_WRAP_SEPARATOR;
             Encoding = DEFAULT_ENCODING;
+            SkipEmptySections = DEFAULT_SKIP_EMPTY_SECTIONS;
         }
 
         [DefaultValue(DEFAULT_WRAP_SEPARATOR)]
@@ -20,5 +23,8 @@ namespace PSDocs.Configuration
 
         [DefaultValue(DEFAULT_ENCODING)]
         public MarkdownEncoding Encoding { get; set; }
+
+        [DefaultValue(DEFAULT_SKIP_EMPTY_SECTIONS)]
+        public bool SkipEmptySections { get; set; }
     }
 }

--- a/src/PSDocs/Configuration/PSDocumentOption.cs
+++ b/src/PSDocs/Configuration/PSDocumentOption.cs
@@ -26,7 +26,8 @@ namespace PSDocs.Configuration
             Markdown = new MarkdownOption
             {
                 WrapSeparator = option.Markdown.WrapSeparator,
-                Encoding = option.Markdown.Encoding
+                Encoding = option.Markdown.Encoding,
+                SkipEmptySections = option.Markdown.SkipEmptySections
             };
         }
 
@@ -119,6 +120,11 @@ namespace PSDocs.Configuration
             if (index.TryGetValue("markdown.encoding", out value))
             {
                 option.Markdown.Encoding = (MarkdownEncoding)Enum.Parse(typeof(MarkdownEncoding), (string)value);
+            }
+
+            if (index.TryGetValue("markdown.skipemptysections", out value))
+            {
+                option.Markdown.SkipEmptySections = (bool)value;
             }
 
             return option;

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -277,7 +277,11 @@ function Section {
 
         # Optionally a condition that must be met prior to including the Section
         [Parameter(Mandatory = $False)]
-        [ScriptBlock]$When
+        [ScriptBlock]$When,
+
+        # Optionally create a section block even when it is empty
+        [Parameter(Mandatory = $False)]
+        [Switch]$Force = $False
     )
 
     begin {
@@ -328,8 +332,13 @@ function Section {
                 return;
             }
 
-            # Emit Section object to the pipeline
-            $result;
+            if ($result.Node.Length -gt 0 -or $Force -or $PSDocs.Option.Markdown.SkipEmptySections -eq $False) {
+                # Emit Section object to the pipeline
+                $result;
+            }
+            else {
+                Write-Verbose -Message "[Doc][Section] -- Skipped, section is empty";
+            }
         }
     }
 

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -199,4 +199,17 @@ Describe 'New-PSDocumentOption' -Tag 'Option' {
             $option.Markdown.WrapSeparator | Should -Be 'ZZZ';
         }
     }
+
+    Context 'Read Markdown.SkipEmptySections' {
+
+        It 'from Hashtable' {
+            $option = New-PSDocumentOption -Option @{ 'Markdown.SkipEmptySections' = $False };
+            $option.Markdown.SkipEmptySections | Should -Be $False;
+        }
+
+        It 'from YAML' {
+            $option = New-PSDocumentOption -Option (Join-Path -Path $here -ChildPath 'PSDocs.Tests.yml');
+            $option.Markdown.SkipEmptySections | Should -Be $False;
+        }
+    }
 }

--- a/tests/PSDocs.Tests/PSDocs.Section.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Section.Tests.ps1
@@ -74,17 +74,40 @@ Describe 'PSDocs -- Section keyword' {
             Section 'MultiLine' {
                 "This is a multiline`r`ntest."
             }
+
+            Section 'Empty' {
+
+            }
+
+            Section 'Forced' -Force {
+
+            }
         }
 
         $outputDoc = "$outputPath\Section.md";
         SectionBlockTests -InstanceName 'Section' -InputObject $dummyObject -OutputPath $outputPath;
 
         It 'Should have generated output' {
-            Test-Path -Path $outputDoc | Should be $True;
+            Test-Path -Path $outputDoc | Should -Be $True;
         }
 
         It 'Should match expected format' {
-            Get-Content -Path $outputDoc -Raw | Should match '## SingleLine(\n|\r){1,2}This is a single line markdown section.(\n|\r){4}## MultiLine(\n|\r){1,2}This is a multiline(\n|\r){1,2}test.';
+            Get-Content -Path $outputDoc -Raw | Should -Match '## SingleLine(\n|\r){1,2}This is a single line markdown section.(\n|\r){4}## MultiLine(\n|\r){1,2}This is a multiline(\n|\r){1,2}test.';
+        }
+
+        It 'Empty section is not present' {
+            Get-Content -Path $outputDoc -Raw | Should -Not -Match '## Empty'
+        }
+
+        It 'Forced section is present' {
+            Get-Content -Path $outputDoc -Raw | Should -Match '## Forced'
+        }
+
+        $outputDoc = "$outputPath\Section2.md";
+        SectionBlockTests -InstanceName 'Section2' -InputObject $dummyObject -OutputPath $outputPath -Option @{ 'Markdown.SkipEmptySections' = $False };
+
+        It 'Empty sections are include with option' {
+            Get-Content -Path $outputDoc -Raw | Should -Match '## Empty'
         }
     }
 

--- a/tests/PSDocs.Tests/PSDocs.Tests.yml
+++ b/tests/PSDocs.Tests/PSDocs.Tests.yml
@@ -2,3 +2,4 @@
 markdown:
   encoding: UTF8
   wrapSeparator: 'ZZZ'
+  skipEmptySections: false


### PR DESCRIPTION
- **Breaking change**: Empty `Section` blocks are not rendered by default
  - Use `-Force` parameter on specific sections or `Markdown.SkipEmptySections = $False` option to force the empty sections to written

Fix #32