### PR TITLE
Added support for inserting external markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Added `BlockQuote` keyword to generate block quotes in addition to existing `Note` and `Warning` keywords which are specific to DocFX
+- Added `Include` keyword to insert content from an external file
 - **Breaking change**: Removed `Import-PSDocumentTemplate` cmdlet. Use `Invoke-PSDocument` instead or dot source
 - **Breaking change**: Removed support for `-Function` parameter of `Invoke-PSDocument`. External commands can be executed in document blocks. Re-evaluating if this is really needed.
 - **Important change**: Renamed `-When` parameter on Section block to `-If`. `-When` is still works but is deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 ## Unreleased
 
 - Added `BlockQuote` keyword to generate block quotes in addition to existing `Note` and `Warning` keywords which are specific to DocFX
+- Added `-Culture` parameter to `Invoke-PSDocument`, which allows generation of multiple localized output files
 - Added `Include` keyword to insert content from an external file
+  - Use the `-UseCulture` switch to include a culture specific external file
 - **Breaking change**: Removed `Import-PSDocumentTemplate` cmdlet. Use `Invoke-PSDocument` instead or dot source
 - **Breaking change**: Removed support for `-Function` parameter of `Invoke-PSDocument`. External commands can be executed in document blocks. Re-evaluating if this is really needed.
 - **Important change**: Renamed `-When` parameter on Section block to `-If`. `-When` is still works but is deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 ## Unreleased
 
 - Added `BlockQuote` keyword to generate block quotes in addition to existing `Note` and `Warning` keywords which are specific to DocFX
+  - See [about_PSDocs_Keywords](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#blockquote) help topic for details
 - Added `-Culture` parameter to `Invoke-PSDocument`, which allows generation of multiple localized output files
 - Added `Include` keyword to insert content from an external file
-  - Use the `-UseCulture` switch to include a culture specific external file
+  - Use the `-UseCulture` switch of `Include` to insert content from a culture specific external file
+  - See [about_PSDocs_Keywords](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#include) help topic for details
+- Added support for locked down environments to ensure that documents are executed as constrained code when Device Guard is used
+  - Use the `Execution.LanguageMode = 'ConstrainedLanguage'` option to force constrained language mode
+- Added new contextual help topic to provide details on automatic variables exposed for PSDocs for use within document definitions
 - **Breaking change**: Removed `Import-PSDocumentTemplate` cmdlet. Use `Invoke-PSDocument` instead or dot source
 - **Breaking change**: Removed support for `-Function` parameter of `Invoke-PSDocument`. External commands can be executed in document blocks. Re-evaluating if this is really needed.
 - **Important change**: Renamed `-When` parameter on Section block to `-If`. `-When` is still works but is deprecated.
-- Added support for locked down environments to ensure that documents are executed as constrained code when Device Guard is used
-  - Use the `Execution.LanguageMode = 'ConstrainedLanguage'` option to force constrained language mode
 - **Important change**: Improved markdown formatting for tables [#31](https://github.com/BernieWhite/PSDocs/issues/31)
   - Table columns are now padded by default to match header width. Set `Markdown.ColumnPadding` option to `None` to match format style from PSDocs <= 0.5.0
   - Pipe characters on the start and end of a table row are not added by default. Set `Markdown.UseEdgePipes` option to `Always` to match format style from PSDocs <= 0.5.0

--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ The following conceptual topics exist in the `PSDocs` module:
   - [Markdown.UseEdgePipes](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#use-edge-pipes)
   - [Execution.LanguageMode](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#language-mode)
 - [Variables](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md)
-  - [Culture](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#culture)
-  - [InstanceName](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#instancename)
+  - [$Culture](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#culture)
+  - [$Document](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#document)
+  - [$InstanceName](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#instancename)
+  - [$InputObject](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#inputobject)
+  - [$Section](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#section)
 
 ## Changes and versioning
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ The following conceptual topics exist in the `PSDocs` module:
   - [Markdown.ColumnPadding](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#column-padding)
   - [Markdown.UseEdgePipes](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#use-edge-pipes)
   - [Execution.LanguageMode](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#language-mode)
+- [Variables](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md)
+  - [Culture](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#culture)
+  - [InstanceName](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#instancename)
 
 ## Changes and versioning
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The following language keywords are used by the `PSDocs` module:
 - [Warning](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#warning) - Inserts a warning using DocFx formatted markdown (DFM)
 - [Metadata](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#metadata) - Inserts a yaml header
 - [Table](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#table) - Inserts a table from pipeline objects
+- [Include](docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md#include) - Insert content from an external file
 
 ### Commands
 

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -284,3 +284,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[New-PSDocumentOption](New-PSDocumentOption.md)

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -17,15 +17,16 @@ Create markdown from an input object.
 
 ```text
 Invoke-PSDocument -Name <String[]> [-InstanceName <String[]>] [-InputObject <PSObject>] [-OutputPath <String>]
- [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
+ [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [-Culture <String[]>]
+ [<CommonParameters>]
 ```
 
 ### Path
 
 ```text
 Invoke-PSDocument [-Name <String[]>] [-Tag <String[]>] [-InstanceName <String[]>] [-InputObject <PSObject>]
- [-Path] <String> [-OutputPath <String>]
- [-PassThru] [-Option <PSDocumentOption>] [-Encoding <MarkdownEncoding>] [<CommonParameters>]
+ [-Path] <String> [-OutputPath <String>] [-PassThru] [-Option <PSDocumentOption>]
+ [-Encoding <MarkdownEncoding>] [-Culture <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -241,6 +242,24 @@ One or more tags that the document definition must contain. If more then one tag
 ```yaml
 Type: String[]
 Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Culture
+
+One or more culture names when building documents that are localized. i.e. en-AU, en-US
+
+When culture names are specified, the generated document will be written to a culture specific subdirectory.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
@@ -10,7 +10,7 @@ Describes the automatic variables that can be used within PSDocs document defini
 
 PSDocs lets you generate dynamic markdown documents using PowerShell blocks. To generate markdown, a document is defined inline or within script files by using the `document` keyword.
 
-Within a document definition, PSDocs exposes a number of automatic variables that can be read to assist with dynamic document generation.
+Within a document definition, PSDocs exposes a number of automatic variables that can be read to assist with dynamic document generation. Overwriting these variables or variable properties is not supported.
 
 The following variables are available for use:
 
@@ -22,11 +22,11 @@ The following variables are available for use:
 
 ### Culture
 
-The name of the culture currently being processed.
+The name of the culture currently being processed. `$Culture` is set by using the `-Culture` parameter of `Invoke-PSDocument` or inline functions.
 
-Cultures specified by using the `-Culture` parameter of `Invoke-PSDocument` or inline functions will be sequentially processed. As each is processed, the `$Culture` variable will take on the current processed culture.
+When more than one culture is set, each will be processed sequentially.
 
-If a culture has not been specified, the culture will default to the culture of the current thread.
+If a culture has not been specified, `$Culture` will default to the culture of the current thread.
 
 Syntax:
 
@@ -36,13 +36,54 @@ $Culture
 
 ### Document
 
+An object representing the current object model of the document during generation.
+
+The following section properties are available for public read access:
+
+- `Title` - The title of the document.
+- `Metadata` - A dictionary of metadata key/value pairs.
+- `Path` - The file path where the document will be written to.
+
+Syntax:
+
+```powershell
+$Document
+```
+
+Examples:
+
+```powershell
+document 'Sample' {
+    Title 'Example'
+
+    # The value of $Document.Title = 'Example'
+    "The title of the document is $($Document.Title)."
+
+    Metadata @{
+        author = 'Bernie'
+    }
+
+    # The value of $Document.Metadata['author'] = 'Bernie'
+    'The author is ' + $Document.Metadata['author'] + '.'
+}
+```
+
+```text
+---
+author: Bernie
+---
+# Example
+The title of the document is Example.
+The author is Bernie.
+```
+
 ### InstanceName
 
-The name of the instance currently being processed.
+The name of the instance currently being processed. `$InstanceName` is set by using the `-InstanceName` parameter of `Invoke-PSDocument` or inline functions.
 
-Instance names specified by using the `-InstanceName` parameter of `Invoke-PSDocument` or inline functions will be sequentially processed. As each is processed, the `$InstanceName` variable will take on the currently processed instance name.
+When more than one instance name is set, each will be processed sequentially.
 
-If an instance name is not specified, the instance name will default to the name of the document.
+If an instance name is not specified, `$InstanceName` will default to the name of the document definition.
 
 Syntax:
 
@@ -54,7 +95,9 @@ $InstanceName
 
 The value of the pipeline object currently being processed. `$InputObject` is set by using the `-InputObject` parameter of `Invoke-PSDocument` or inline functions.
 
-When more than one `$InputObject` is set, each object will be processed sequentially.
+When more than one input object is set, each object will be processed sequentially.
+
+If an input object is not specified, `$InputObject` will default to `$Null`.
 
 Syntax:
 
@@ -68,10 +111,10 @@ An object of the document section currently being processed.
 
 As `Section` blocks are processed, the `$Section` variable will be updated to match the block that is currently being processed. `$Section` will be the current document outside of `Section` blocks.
 
-The following properties are available for the section node:
+The following section properties are available for public read access:
 
 - `Title` - The title of the section, or the document (when outside of a section block).
-- `Level` - The section heading depth. This will be `2` (or greater for nested sections), or 1 (when outside of a section block).
+- `Level` - The section heading depth. This will be _2_ (or greater for nested sections), or _1_ (when outside of a section block).
 
 Syntax:
 

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
@@ -10,11 +10,19 @@ Describes the automatic variables that can be used within PSDocs document defini
 
 PSDocs lets you generate dynamic markdown documents using PowerShell blocks. To generate markdown, a document is defined inline or within script files by using the `document` keyword.
 
-Within a document definition, PSDocs exposes a number of automatic variables.
+Within a document definition, PSDocs exposes a number of automatic variables that can be read to assist with dynamic document generation.
+
+The following variables are available for use:
+
+- [$Culture](#culture)
+- [$Document](#document)
+- [$InstanceName](#instancename)
+- [$InputObject](#inputobject)
+- [$Section](#section)
 
 ### Culture
 
-The culture of the document currently being processed.
+The name of the culture currently being processed.
 
 Cultures specified by using the `-Culture` parameter of `Invoke-PSDocument` or inline functions will be sequentially processed. As each is processed, the `$Culture` variable will take on the current processed culture.
 
@@ -25,6 +33,8 @@ Syntax:
 ```powershell
 $Culture
 ```
+
+### Document
 
 ### InstanceName
 
@@ -40,6 +50,52 @@ Syntax:
 $InstanceName
 ```
 
+### InputObject
+
+The value of the pipeline object currently being processed. `$InputObject` is set by using the `-InputObject` parameter of `Invoke-PSDocument` or inline functions.
+
+When more than one `$InputObject` is set, each object will be processed sequentially.
+
+Syntax:
+
+```powershell
+$InputObject
+```
+
+### Section
+
+An object of the document section currently being processed.
+
+As `Section` blocks are processed, the `$Section` variable will be updated to match the block that is currently being processed. `$Section` will be the current document outside of `Section` blocks.
+
+The following properties are available for the section node:
+
+- `Title` - The title of the section, or the document (when outside of a section block).
+- `Level` - The section heading depth. This will be `2` (or greater for nested sections), or 1 (when outside of a section block).
+
+Syntax:
+
+```powershell
+$Section
+```
+
+Examples:
+
+```powershell
+document 'Sample' {
+    Section 'Introduction' {
+        # The value of $Section.Title = 'Introduction'
+        "The current title is $($Section.Title)."
+    }
+}
+```
+
+```text
+## Introduction
+
+The current section title is Introduction.
+```
+
 ## NOTE
 
 An online version of this document is available at https://github.com/BernieWhite/PSDocs/blob/master/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md.
@@ -51,4 +107,7 @@ An online version of this document is available at https://github.com/BernieWhit
 ## KEYWORDS
 
 - Culture
+- Document
 - InstanceName
+- InputObject
+- Section

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
@@ -1,0 +1,54 @@
+# PSDocs_Variables
+
+## about_PSDocs_Variables
+
+## SHORT DESCRIPTION
+
+Describes the automatic variables that can be used within PSDocs document definitions.
+
+## LONG DESCRIPTION
+
+PSDocs lets you generate dynamic markdown documents using PowerShell blocks. To generate markdown, a document is defined inline or within script files by using the `document` keyword.
+
+Within a document definition, PSDocs exposes a number of automatic variables.
+
+### Culture
+
+The culture of the document currently being processed.
+
+Cultures specified by using the `-Culture` parameter of `Invoke-PSDocument` or inline functions will be sequentially processed. As each is processed, the `$Culture` variable will take on the current processed culture.
+
+If a culture has not been specified, the culture will default to the culture of the current thread.
+
+Syntax:
+
+```powershell
+$Culture
+```
+
+### InstanceName
+
+The name of the instance currently being processed.
+
+Instance names specified by using the `-InstanceName` parameter of `Invoke-PSDocument` or inline functions will be sequentially processed. As each is processed, the `$InstanceName` variable will take on the currently processed instance name.
+
+If an instance name is not specified, the instance name will default to the name of the document.
+
+Syntax:
+
+```powershell
+$InstanceName
+```
+
+## NOTE
+
+An online version of this document is available at https://github.com/BernieWhite/PSDocs/blob/master/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md.
+
+## SEE ALSO
+
+- [Invoke-PSDocument](https://github.com/BernieWhite/PSDocs/blob/master/docs/commands/PSDocs/en-US/Invoke-PSDocument.md)
+
+## KEYWORDS
+
+- Culture
+- InstanceName

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -510,17 +510,19 @@ Insert content from an external file into this document.
 Syntax:
 
 ```text
-Include [-FileName] <String> [-BaseDirectory <String>]
+Include [-FileName] <String> [-BaseDirectory <String>] [-UseCulture]
 ```
 
 - `FileName` - The path to a markdown file to include. An absolute or relative path is accepted.
 - `BaseDirectory` - The base path to work from for relative paths specified with the `FileName` parameter. By default this is the current working path.
+- `UseCulture` - When specified include will look for the file within a subdirectory for a named culture.
 
 Examples:
 
 ```powershell
 # A document definition
 Document 'Sample' {
+    # Include IncludeFile.md from the current working path
     Include IncludeFile.md
 }
 ```
@@ -532,7 +534,20 @@ This is included from an external file.
 ```powershell
 # A document definition
 Document 'Sample' {
+    # Include IncludeFile.md from docs/
     Include IncludeFile.md -BaseDirectory docs
+}
+```
+
+```text
+This is included from an external file.
+```
+
+```powershell
+# A document definition
+Document 'Sample' {
+    # Include IncludeFile.md from docs/<culture>/. i.e. docs/en-AU/
+    Include IncludeFile.md -BaseDirectory docs -UseCulture
 }
 ```
 

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -23,6 +23,7 @@ The following PSDocs keywords are available:
 - Warning - Inserts a warning using DocFx formatted markdown (DFM)
 - Table - Inserts a table from pipeline objects
 - Metadata - Inserts a YAML header
+- Include - Insert content from an external file
 
 ### Document
 
@@ -502,6 +503,43 @@ last-updated: 2018-05-17
 Yaml header may not be rendered by some markdown viewers. See source to view yaml.
 ```
 
+### Include
+
+Insert content from an external file into this document.
+
+Syntax:
+
+```text
+Include [-FileName] <String> [-BaseDirectory <String>]
+```
+
+- `FileName` - The path to a markdown file to include. An absolute or relative path is accepted.
+- `BaseDirectory` - The base path to work from for relative paths specified with the `FileName` parameter. By default this is the current working path.
+
+Examples:
+
+```powershell
+# A document definition
+Document 'Sample' {
+    Include IncludeFile.md
+}
+```
+
+```text
+This is included from an external file.
+```
+
+```powershell
+# A document definition
+Document 'Sample' {
+    Include IncludeFile.md -BaseDirectory docs
+}
+```
+
+```text
+This is included from an external file.
+```
+
 ## EXAMPLES
 
 ```powershell
@@ -540,3 +578,4 @@ An online version of this document is available at https://github.com/BernieWhit
 - Table
 - Metadata
 - Yaml
+- Include

--- a/src/PSDocs/Models/DocumentNodeType.cs
+++ b/src/PSDocs/Models/DocumentNodeType.cs
@@ -10,12 +10,10 @@
 
         Code,
 
-        Note,
-
-        Warning,
-
         BlockQuote,
 
-        Text
+        Text,
+
+        Include
     }
 }

--- a/src/PSDocs/Models/Include.cs
+++ b/src/PSDocs/Models/Include.cs
@@ -1,0 +1,9 @@
+﻿namespace PSDocs.Models
+{
+    public sealed class Include : DocumentNode
+    {
+        public override DocumentNodeType Type => DocumentNodeType.Include;
+
+        public string Path { get; set; }
+    }
+}

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -1,4 +1,7 @@
-﻿namespace PSDocs.Models
+﻿using PSDocs.Configuration;
+using System.IO;
+
+namespace PSDocs.Models
 {
     public static class ModelHelper
     {
@@ -46,6 +49,26 @@
             return new Text
             {
                 Content = value
+            };
+        }
+
+        public static Include Include(string baseDirectory, string culture, string fileName)
+        {
+            var absolutePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(baseDirectory, fileName);
+
+            if (!Path.IsPathRooted(absolutePath))
+            {
+                absolutePath = Path.Combine(PSDocumentOption.GetWorkingPath(), absolutePath);
+            }
+
+            if (!File.Exists(absolutePath))
+            {
+                throw new FileNotFoundException("The included file was not found.", absolutePath);
+            }
+
+            return new Include
+            {
+                Path = absolutePath
             };
         }
     }

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -52,9 +52,9 @@ namespace PSDocs.Models
             };
         }
 
-        public static Include Include(string baseDirectory, string culture, string fileName)
+        public static Include Include(string baseDirectory, string culture, string fileName, bool useCulture)
         {
-            var absolutePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(baseDirectory, fileName);
+            var absolutePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(baseDirectory, (useCulture ? culture : string.Empty), fileName);
 
             if (!Path.IsPathRooted(absolutePath))
             {

--- a/src/PSDocs/Models/Note.cs
+++ b/src/PSDocs/Models/Note.cs
@@ -1,9 +1,0 @@
-﻿namespace PSDocs.Models
-{
-    public sealed class Note : DocumentNode
-    {
-        public override DocumentNodeType Type => DocumentNodeType.Note;
-
-        public string[] Content { get; set; }
-    }
-}

--- a/src/PSDocs/Models/PSDocsContext.cs
+++ b/src/PSDocs/Models/PSDocsContext.cs
@@ -15,6 +15,8 @@ namespace PSDocs.Models
 
         public string[] InstanceName { get; set; }
 
+        public string[] Culture { get; set; }
+
         public WriteDocumentDelegate WriteDocumentHook { get; set; }
 
         public static PSDocsContext Create(PSDocumentOption option, string[] name, string[] tag)

--- a/src/PSDocs/Models/Warning.cs
+++ b/src/PSDocs/Models/Warning.cs
@@ -1,9 +1,0 @@
-﻿namespace PSDocs.Models
-{
-    public sealed class Warning : DocumentNode
-    {
-        public override DocumentNodeType Type => DocumentNodeType.Warning;
-
-        public string[] Content { get; set; }
-    }
-}

--- a/src/PSDocs/PSDocs.psd1
+++ b/src/PSDocs/PSDocs.psd1
@@ -80,6 +80,7 @@ FunctionsToExport = @(
     'BlockQuote'
     'Note'
     'Warning'
+    'Include'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -1406,7 +1406,7 @@ function GetRunspace {
             'PSDocs',
             $PSDocs,
             $Null,
-            [System.Management.Automation.ScopedItemOptions]::AllScope
+            [System.Management.Automation.ScopedItemOptions]::Constant
         )));
         $iss.Variables.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList @(
             'VerbosePreference',
@@ -1417,6 +1417,12 @@ function GetRunspace {
             'ErrorActionPreference',
             [System.Management.Automation.ActionPreference]::Stop,
             $Null
+        )));
+        $iss.Variables.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList @(
+            'PWD',
+            $PWD,
+            $Null,
+            [System.Management.Automation.ScopedItemOptions]::Constant
         )));
         $rs = [RunspaceFactory]::CreateRunspace($iss);
         $rs.Open();

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -555,6 +555,30 @@ function BlockQuote {
     }
 }
 
+function Include {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 0, Mandatory = $True)]
+        [String]$FileName,
+
+        [Parameter(Mandatory = $False)]
+        [String]$BaseDirectory = $PWD,
+
+        [Parameter(Mandatory = $False)]
+        [String]$Culture,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$Localized = $False
+    )
+
+    process {
+        $result = [PSDocs.Models.ModelHelper]::Include($BaseDirectory, $Culture, $FileName);
+
+        $result;
+    }
+}
+
 function Metadata {
 
     [CmdletBinding()]
@@ -1340,6 +1364,10 @@ function GetRunspace {
             ${function:Metadata}
         )));
         $iss.Commands.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList @(
+            'Include',
+            ${function:Include}
+        )));
+        $iss.Commands.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList @(
             'GetObjectField',
             ${function:GetObjectField}
         )));
@@ -1453,6 +1481,7 @@ function InitEditorServices {
             'BlockQuote'
             'Note'
             'Warning'
+            'Include'
         );
     }
 }

--- a/src/PSDocs/Processor/Markdown/MarkdownProcessor.cs
+++ b/src/PSDocs/Processor/Markdown/MarkdownProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using PSDocs.Configuration;
 using PSDocs.Models;
 
@@ -93,21 +94,15 @@ namespace PSDocs.Processor.Markdown
 
                         break;
 
-                    case DocumentNodeType.Note:
-
-                        Note(context, documentNode as Note);
-
-                        break;
-
-                    case DocumentNodeType.Warning:
-
-                        Warning(context, documentNode as Warning);
-
-                        break;
-
                     case DocumentNodeType.Text:
 
                         Text(context, documentNode as Text);
+
+                        break;
+
+                    case DocumentNodeType.Include:
+
+                        Include(context, documentNode as Include);
 
                         break;
                 }
@@ -166,28 +161,6 @@ namespace PSDocs.Processor.Markdown
             }
         }
 
-        private void Warning(MarkdownProcessorContext context, Warning warning)
-        {
-            context.WriteLine(string.Empty);
-            context.WriteLine("> [!WARNING]");
-
-            foreach (var line in warning.Content)
-            {
-                context.WriteLine("> ", line);
-            }
-        }
-
-        private void Note(MarkdownProcessorContext context, Note note)
-        {
-            context.WriteLine(string.Empty);
-            context.WriteLine("> [!NOTE]");
-
-            foreach (var line in note.Content)
-            {
-                context.WriteLine("> ", line);
-            }
-        }
-
         private void Code(MarkdownProcessorContext context, Code code)
         {
             if (string.IsNullOrEmpty(code.Info))
@@ -207,6 +180,12 @@ namespace PSDocs.Processor.Markdown
         private void Text(MarkdownProcessorContext context, Text text)
         {
             context.WriteLine(text.Content);
+        }
+
+        private void Include(MarkdownProcessorContext context, Include include)
+        {
+            var text = File.ReadAllText(include.Path);
+            context.WriteLine(text);
         }
 
         private void Table(MarkdownProcessorContext context, Table table)

--- a/tests/PSDocs.Tests/IncludeFile.md
+++ b/tests/PSDocs.Tests/IncludeFile.md
@@ -1,0 +1,1 @@
+This is included from an external file.

--- a/tests/PSDocs.Tests/IncludeFile2.md
+++ b/tests/PSDocs.Tests/IncludeFile2.md
@@ -1,0 +1,1 @@
+This is a second file to include.

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -351,5 +351,24 @@ Describe 'PSDocs variables' -Tag 'Variables' {
             $result = PSAutomaticVariables -PassThru;
             $result.Split("`r`n") | Where-Object -FilterScript { $_ -like "PWD=*" } | Should -Be "PWD=$PWD";
         }
-    } 
+    }
+
+    Context 'PSDocs automatic variables' {
+
+        document 'PSDocsAutomaticVariables' {
+            Title '001'
+            Metadata @{
+                author = '002'
+            }
+
+            "Document.Title=$($document.Title)"
+            "Document.Metadata=$($document.Metadata['author'])"
+        }
+
+        It '$Document' {
+            $result = (PSDocsAutomaticVariables -PassThru).Split("`r`n");
+            $result | Where-Object -FilterScript { $_ -like "Document.Title=*" } | Should -Be "Document.Title=001";
+            $result | Where-Object -FilterScript { $_ -like "Document.Metadata=*" } | Should -Be "Document.Metadata=002";
+        }
+    }
 }

--- a/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Common.Tests.ps1
@@ -339,3 +339,17 @@ Describe 'New-PSDocumentOption' -Tag 'Option' {
         }
     }
 }
+
+Describe 'PSDocs variables' -Tag 'Variables' {
+    Context 'PowerShell automatic variables' {
+
+        document 'PSAutomaticVariables' {
+            "PWD=$PWD"
+        }
+
+        It '$PWD' {
+            $result = PSAutomaticVariables -PassThru;
+            $result.Split("`r`n") | Where-Object -FilterScript { $_ -like "PWD=*" } | Should -Be "PWD=$PWD";
+        }
+    } 
+}

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -1,0 +1,52 @@
+#
+# Unit tests for the Include keyword
+#
+
+[CmdletBinding()]
+param (
+
+)
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+# Setup tests paths
+$rootPath = $PWD;
+
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSDocs) -Force;
+
+$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSDocs.Tests/Include;
+Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+$Null = New-Item -Path $outputPath -ItemType Directory -Force;
+
+Describe 'PSDocs -- Include keyword' -Tag Include {
+    Context 'Markdown' {
+
+        It 'Should include a relative path' {
+            document 'IncludeRelative' {
+                Include tests/PSDocs.Tests/IncludeFile.md
+                Include IncludeFile2.md -BaseDirectory tests/PSDocs.Tests/
+            }
+
+            $outputDoc = "$outputPath\IncludeRelative.md";
+            IncludeRelative -OutputPath $outputPath;
+
+            Test-Path -Path $outputDoc | Should be $True;
+            $outputDoc | Should -FileContentMatch 'This is included from an external file.';
+            $outputDoc | Should -FileContentMatch 'This is a second file to include.';
+        }
+
+        It 'Should include an absolute path' {
+            document 'IncludeAbsolute' {
+                Include (Join-Path -Path $PWD -ChildPath tests/PSDocs.Tests/IncludeFile.md)
+            }
+
+            $outputDoc = "$outputPath\IncludeAbsolute.md";
+            IncludeAbsolute -OutputPath $outputPath;
+
+            Test-Path -Path $outputDoc | Should be $True;
+            $outputDoc | Should -FileContentMatch 'This is included from an external file.';
+        }
+    }
+}

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
             $outputDoc = "$outputPath\IncludeRelative.md";
             IncludeRelative -OutputPath $outputPath;
 
-            Test-Path -Path $outputDoc | Should be $True;
+            Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';
             $outputDoc | Should -FileContentMatch 'This is a second file to include.';
         }
@@ -45,8 +45,24 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
             $outputDoc = "$outputPath\IncludeAbsolute.md";
             IncludeAbsolute -OutputPath $outputPath;
 
-            Test-Path -Path $outputDoc | Should be $True;
+            Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';
+        }
+
+        It 'Should include from culture' {
+            document 'IncludeCulture' {
+                Include IncludeFile3.md -UseCulture -BaseDirectory tests/PSDocs.Tests/
+            }
+
+            IncludeCulture -OutputPath $outputPath -Culture 'en-AU','en-US' -Verbose;
+
+            $outputDoc = "$outputPath\en-AU\IncludeCulture.md";
+            Test-Path -Path $outputDoc | Should -Be $True;
+            $outputDoc | Should -FileContentMatch 'This is en-AU.';
+
+            $outputDoc = "$outputPath\en-US\IncludeCulture.md";
+            Test-Path -Path $outputDoc | Should -Be $True;
+            $outputDoc | Should -FileContentMatch 'This is en-US.';
         }
     }
 }

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -25,12 +25,12 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
 
         It 'Should include a relative path' {
             document 'IncludeRelative' {
-                Include tests/PSDocs.Tests/IncludeFile.md
-                Include IncludeFile2.md -BaseDirectory tests/PSDocs.Tests/
+                Include tests/PSDocs.Tests/IncludeFile.md -BaseDirectory $InputObject
+                Include IncludeFile2.md -BaseDirectory (Join-Path -Path $InputObject -ChildPath tests/PSDocs.Tests/)
             }
 
             $outputDoc = "$outputPath\IncludeRelative.md";
-            IncludeRelative -OutputPath $outputPath;
+            IncludeRelative -InputObject $rootPath -OutputPath $outputPath;
 
             Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';
@@ -39,11 +39,11 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
 
         It 'Should include an absolute path' {
             document 'IncludeAbsolute' {
-                Include (Join-Path -Path $PWD -ChildPath tests/PSDocs.Tests/IncludeFile.md)
+                Include (Join-Path -Path $InputObject -ChildPath tests/PSDocs.Tests/IncludeFile.md)
             }
 
             $outputDoc = "$outputPath\IncludeAbsolute.md";
-            IncludeAbsolute -OutputPath $outputPath;
+            IncludeAbsolute -InputObject $rootPath -OutputPath $outputPath;
 
             Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
                 Include IncludeFile3.md -UseCulture -BaseDirectory tests/PSDocs.Tests/
             }
 
-            IncludeCulture -OutputPath $outputPath -Culture 'en-AU','en-US' -Verbose;
+            IncludeCulture -OutputPath $outputPath -Culture 'en-AU','en-US';
 
             $outputDoc = "$outputPath\en-AU\IncludeCulture.md";
             Test-Path -Path $outputDoc | Should -Be $True;

--- a/tests/PSDocs.Tests/en-AU/IncludeFile3.md
+++ b/tests/PSDocs.Tests/en-AU/IncludeFile3.md
@@ -1,0 +1,1 @@
+This is en-AU.

--- a/tests/PSDocs.Tests/en-US/IncludeFile3.md
+++ b/tests/PSDocs.Tests/en-US/IncludeFile3.md
@@ -1,0 +1,1 @@
+This is en-US.


### PR DESCRIPTION
- Added `Include` keyword to insert markdown from external files
- Added `-Culture` parameter to `Invoke-PSDocument` to provide localized includes based on current culture
- Added new about help topic to provide details about automatic variables available within document definitions