### PR TITLE
Fix handling of null metadata #60 #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 
 ## Unreleased
 
+- Fix PositionMessage cannot be found on this object. [#63](https://github.com/BernieWhite/PSDocs/issues/63)
+- Fix handling of null metadata hashtable. [#60](https://github.com/BernieWhite/PSDocs/issues/60)
+
 ## v0.6.1
 
-- Fix null reference for table columns with undefined properties [#53](https://github.com/BernieWhite/PSDocs/issues/53)
+- Fix null reference for table columns with undefined properties. [#53](https://github.com/BernieWhite/PSDocs/issues/53)
 
 ## v0.6.0
 

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -600,16 +600,17 @@ function Include {
 }
 
 function Metadata {
-
     [CmdletBinding()]
     param (
         [Parameter(Position = 0, Mandatory = $True)]
+        [AllowNull()]
         [System.Collections.IDictionary]$Body
     )
-
     process {
-
-        # Process eaxch key value pair in the supplied dictionary/hashtable
+        if ($Null -eq $Body) {
+            return;
+        }
+        # Process each key value pair in the supplied dictionary/hashtable
         foreach ($kv in $Body.GetEnumerator()) {
             $Document.Metadata[$kv.Key] = $kv.Value;
         }
@@ -1307,8 +1308,10 @@ function InvokeTemplate {
                 $baseException = $_.Exception.GetBaseException();
                 $positionMessage = $Null;
 
-                if ($baseException -is [System.Management.Automation.IContainsErrorRecord]) {
-                    $positionMessage = $baseException.ErrorRecord.InvocationInfo.PositionMessage
+                if ($baseException -is [System.Management.Automation.IContainsErrorRecord] -and $Null -ne $baseException.ErrorRecord.InvocationInfo) {
+                    if (![String]::IsNullOrEmpty($baseException.ErrorRecord.InvocationInfo.PositionMessage)) {
+                        $positionMessage = $baseException.ErrorRecord.InvocationInfo.PositionMessage
+                    }
                 }
 
                 throw (New-Object -TypeName PSDocs.Execution.InvokeDocumentException -ArgumentList @(

--- a/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Metadata.Tests.ps1
@@ -27,12 +27,9 @@ $dummyObject = New-Object -TypeName PSObject;
 $Global:TestVars = @{ };
 
 Describe 'PSDocs -- Metadata keyword' {
-
     Context 'Metadata single entry' {
-        
         # Define a test document with metadata content
         document 'MetadataSingleEntry' {
-            
             Metadata ([ordered]@{
                 title = 'Test'
             })
@@ -51,10 +48,8 @@ Describe 'PSDocs -- Metadata keyword' {
     }
 
     Context 'Metadata multiple entries' {
-        
         # Define a test document with metadata content
         document 'MetadataMultipleEntry' {
-            
             Metadata ([ordered]@{
                 value1 = 'ABC'
                 value2 = 'EFG'
@@ -74,10 +69,8 @@ Describe 'PSDocs -- Metadata keyword' {
     }
 
     Context 'Metadata multiple blocks' {
-        
         # Define a test document with metadata content
         document 'MetadataMultipleBlock' {
-            
             Metadata ([ordered]@{
                 value1 = 'ABC'
             })
@@ -104,10 +97,8 @@ Describe 'PSDocs -- Metadata keyword' {
     }
 
     Context 'Document without Metadata block' {
-
         # Define a test document without metadata content
         document 'NoMetdata' {
-
             Section 'Test' {
                 'A test section.'
             }
@@ -125,8 +116,28 @@ Describe 'PSDocs -- Metadata keyword' {
         }
     }
 
+    Context 'Document null Metadata block' {
+        # Define a test document with null metadata content
+        document 'NullMetdata' {
+            Metadata $Null
+            Section 'Test' {
+                'A test section.'
+            }
+        }
+
+        $outputDoc = "$outputPath\NullMetdata.md";
+        NullMetdata -InputObject $dummyObject -OutputPath $outputPath;
+
+        It 'Should have generated output' {
+            Test-Path -Path $outputDoc | Should be $True;
+        }
+
+        It 'Should match expected format' {
+            Get-Content -Path $outputDoc -Raw | Should not match '---\r\n';
+        }
+    }
+
     Context 'Get Metadata header' {
-        
         $result = Get-PSDocumentHeader -Path $outputPath;
 
         It 'Should have data' {


### PR DESCRIPTION
## PR Summary

- Fix PositionMessage cannot be found on this object. #63
- Fix handling of null metadata hashtable. #60

Fixes #63 
Fixes #60 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/master/CHANGELOG.md) has been updated with change under unreleased section
