### PR TITLE
Pre-release v0.7.0-B2008022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.7.0-B2008022 (pre-release)
+
+What's changed since v0.6.3:
+
 - Engine features:
   - Added support for MacOS and Linux. [#59](https://github.com/BernieWhite/PSDocs/issues/59)
 - Deprecations and removals:


### PR DESCRIPTION
## PR Summary

What's changed since v0.6.3:

- Engine features:
  - Added support for MacOS and Linux. #59
- Deprecations and removals:
  - Added upgrade notes for migration from v0.6.x to v0.7.0.
  - **Breaking change**: Removed support for inline document blocks.
    - Use `Invoke-PSDocument` with `.Doc.ps1` files instead.
  - **Breaking change**: Removed script block usage of `Note` and `Warning`.
    - Script block support was previously deprecated in v0.6.0.
    - Use pipeline instead.
  - **Breaking change**: Removed support for `-When` section parameter.
    - `-When` was previously replaced with `-If` in v0.6.0.
- Engineering:
  - Bump YamlDotNet dependency to v8.1.2.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
