### PR TITLE
Automatically serialize Code objects #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ What's changed since pre-release v0.7.0-B2008035:
 
 - Engine features:
   - Added support for localized strings using the `$LocalizedData` variable. [#91](https://github.com/BernieWhite/PSDocs/issues/91)
+  - Automatically serialize `Code` objects to JSON and YAML. [#93](https://github.com/BernieWhite/PSDocs/issues/93)
+    - Use the `json`, `yaml`, or `yml` info strings to automatically serialize custom objects.
+    - See `about_PSDocs_Keywords` for more details.
+- General improvements:
   - Added configuration for setting output options. [#105](https://github.com/BernieWhite/PSDocs/issues/105)
   - Added parameter alias `-MarkdownEncoding` on `New-PSDocumentOption` for `-Encoding`. [#106](https://github.com/BernieWhite/PSDocs/issues/106)
+  - Default the info string to `powershell` for `Code` script blocks. [#92](https://github.com/BernieWhite/PSDocs/issues/92)
+    - See `about_PSDocs_Keywords` for more details.
 - Bug fixes:
   - Fixed inconsistencies with default options file name. [#103](https://github.com/BernieWhite/PSDocs/issues/103)
   - Fixed line break after block quote. [#104](https://github.com/BernieWhite/PSDocs/issues/104)

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -8,7 +8,8 @@ Describes the language keywords that can be used within PSDocs document definiti
 
 ## LONG DESCRIPTION
 
-PSDocs lets you generate dynamic markdown documents using PowerShell blocks. To generate markdown, a document is defined inline or within script files by using the `document` keyword.
+PSDocs lets you generate dynamic markdown documents using PowerShell blocks.
+To generate markdown, a document is defined inline or within script files by using the `document` keyword.
 
 Within a document definition, PSDocs keywords in addition to regular PowerShell expressions can be used to dynamically generate documents.
 
@@ -27,7 +28,8 @@ The following PSDocs keywords are available:
 
 ### Document
 
-Defines a named block that can be called to output documentation. The document keyword can be defined inline or in a separate script file.
+Defines a named block that can be called to output documentation.
+The document keyword can be defined inline or in a separate script file.
 
 Syntax:
 
@@ -217,15 +219,29 @@ Generates a new `Sample.md` document containing the heading `Level 1`.
 
 ### Code
 
-You can use the Code statement to generate fenced code sections in markdown. An info string can optionally be specified using the `-Info` parameter.
+You can use the Code statement to generate fenced code sections in markdown.
+An info string can optionally be specified using the `-Info` parameter.
 
-Syntax:
+Syntax with block:
 
 ```text
 Code [-Info] [<String>] [-Body] <ScriptBlock>
 ```
 
+Syntax with pipeline:
+
+```text
+<object> | Code [-Info] [<String>]
+```
+
 - `Info` - An info string that can be used to specify the language of the code block.
+By default, no info string will be set unless a script block is used.
+When a script block is used, the info string will default to `powershell` unless overridden.
+
+When the following info strings are used, PSDocs will automatic serialize custom objects.
+
+- `json` - Serializes as JSON.
+- `yaml`, or `yml` - Serializes as YAML.
 
 Examples:
 
@@ -242,7 +258,7 @@ Document 'CodeBlock' {
 
 Generates a new `CodeBlock.md` document containing the `powershell.exe -Help` command line.
 
-    ```
+    ```powershell
     powershell.exe -Help
     ```
 
@@ -257,7 +273,7 @@ Document 'CodeBlockWithInfo' {
 }
 ```
 
-Generates a new document containing script code formatted with the powershell info string.
+Generates a new document containing script code formatted with the `powershell` info string.
 
     ```powershell
     Get-Item -Path .\;
@@ -271,6 +287,22 @@ Document 'CodeBlockFromPipeline' {
     Get-Help 'Invoke-PSDocument' | Code
 }
 ```
+
+Generates a new document from the output of `Get-Help`.
+
+```powershell
+Document 'CodeYaml' {
+    [PSCustomObject]@{
+        Name = 'Value'
+    } | Code 'yaml'
+}
+```
+
+Generates a new document with a YAML code block.
+
+    ```yaml
+    Name: Value
+    ```
 
 ### BlockQuote
 
@@ -333,7 +365,8 @@ Document 'BlockQuote' {
 
 ### Note
 
-Creates a block quote formatted as a DocFx Formatted Markdown (DFM) note. This is an alternative to using the `BlockQuote` keyword.
+Creates a block quote formatted as a DocFx Formatted Markdown (DFM) note.
+This is an alternative to using the `BlockQuote` keyword.
 
 Syntax:
 
@@ -341,7 +374,8 @@ Syntax:
 Note -Text <String>
 ```
 
-- `Text` - The text of the note. This parameter can be specified directly or accept input from the pipeline.
+- `Text` - The text of the note.
+This parameter can be specified directly or accept input from the pipeline.
 
 Examples:
 
@@ -363,7 +397,8 @@ Generates a new `NoteBlock.md` document containing a block quote formatted as a 
 
 ### Warning
 
-Creates a block quote formatted as a DocFx Formatted Markdown (DFM) warning. This is an alternative to using the `BlockQuote` keyword.
+Creates a block quote formatted as a DocFx Formatted Markdown (DFM) warning.
+This is an alternative to using the `BlockQuote` keyword.
 
 Syntax:
 
@@ -371,7 +406,8 @@ Syntax:
 Warning -Text <String>
 ```
 
-- `Text` - The text of the warning. This parameter can be specified directly or accept input from the pipeline.
+- `Text` - The text of the warning.
+This parameter can be specified directly or accept input from the pipeline.
 
 Examples:
 
@@ -431,7 +467,8 @@ Users | True
 Windows | True
 ```
 
-Generates a new `SimpleTable.md` document containing a table populated with a row for each item. Only the properties Name and PSIsContainer are added as columns.
+Generates a new `SimpleTable.md` document containing a table populated with a row for each item.
+Only the properties Name and PSIsContainer are added as columns.
 
 ```powershell
 # A document definition named CalculatedTable
@@ -456,11 +493,14 @@ Users               | True
 Windows             | True
 ```
 
-Generates a new `CalculatedTable.md` document containing a table populated with a row for each item. Only the properties Name and Is Container are added as columns. A property expression is used on the `PSIsContainer` property to render the column as `Is Container`.
+Generates a new `CalculatedTable.md` document containing a table populated with a row for each item.
+Only the properties Name and Is Container are added as columns.
+A property expression is used on the `PSIsContainer` property to render the column as `Is Container`.
 
 ### Metadata
 
-Creates a metadata header, that will be rendered as yaml front matter. Multiple `Metadata` blocks can be used and they will be aggregated together.
+Creates a metadata header, that will be rendered as yaml front matter.
+Multiple `Metadata` blocks can be used and they will be aggregated together.
 
 Syntax:
 
@@ -492,7 +532,8 @@ Document 'MetadataBlock' {
 MetadataBlock;
 ```
 
-Generates a new MetadataBlock.md document containing a yaml front matter. An example of the output generated is available [here](/docs/examples/Yaml-header-output.md).
+Generates a new MetadataBlock.md document containing a yaml front matter.
+An example of the output generated is available [here](/docs/examples/Yaml-header-output.md).
 
 ```text
 ---
@@ -514,7 +555,8 @@ Include [-FileName] <String> [-BaseDirectory <String>] [-UseCulture]
 ```
 
 - `FileName` - The path to a markdown file to include. An absolute or relative path is accepted.
-- `BaseDirectory` - The base path to work from for relative paths specified with the `FileName` parameter. By default this is the current working path.
+- `BaseDirectory` - The base path to work from for relative paths specified with the `FileName` parameter.
+By default this is the current working path.
 - `UseCulture` - When specified include will look for the file within a subdirectory for a named culture.
 
 Examples:

--- a/src/PSDocs/Commands/CodeCommand.cs
+++ b/src/PSDocs/Commands/CodeCommand.cs
@@ -1,9 +1,13 @@
 ﻿
+using Newtonsoft.Json;
 using PSDocs.Models;
 using PSDocs.Runtime;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Management.Automation;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace PSDocs.Commands
 {
@@ -14,6 +18,8 @@ namespace PSDocs.Commands
         private const string ParameterSet_InfoString = "InfoString";
         private const string ParameterSet_PipelineInfoString = "PipelineInfoString";
         private const string ParameterSet_Default = "Default";
+
+        private const string Info_ScriptBlock = "powershell";
 
         private List<string> _Content;
 
@@ -60,12 +66,93 @@ namespace PSDocs.Commands
 
         private void AddContent(object input)
         {
-            var s = input?.ToString();
-            if (s == null || string.IsNullOrEmpty(s))
+            var result = TryConvertScriptBlock(input, Info, out StringContent content) ||
+                TryConvertJson(input, Info, out content) ||
+                TryConvertYaml(input, Info, out content) ||
+                TryConvertString(input, Info, out content);
+
+            if (!result || content == null)
                 return;
 
-            var content = new StringContent(s);
             _Content.AddRange(content.ReadLines());
+            Info = content.Info;
+        }
+
+        private static bool TryConvertJson(object input, string info, out StringContent content)
+        {
+            content = null;
+            if (!IsJson(info))
+                return false;
+
+            var baseObject = ObjectHelper.GetBaseObject(input);
+            var baseType = baseObject.GetType();
+            if (baseObject is string || baseType.IsValueType)
+                return false;
+
+            using (StringWriter sw = new StringWriter())
+            {
+                using (JsonTextWriter writer = new JsonTextWriter(sw))
+                {
+                    writer.Indentation = 4;
+                    JsonSerializer serializer = new JsonSerializer();
+                    serializer.Converters.Insert(0, new PSObjectJsonConverter());
+                    serializer.Formatting = Formatting.Indented;
+                    serializer.Serialize(writer, input);
+                }
+                content = new StringContent(sw.ToString(), info);
+            }
+            return true;
+        }
+
+        private static bool TryConvertYaml(object input, string info, out StringContent content)
+        {
+            content = null;
+            if (!IsYaml(info))
+                return false;
+
+            var baseObject = ObjectHelper.GetBaseObject(input);
+            var baseType = baseObject.GetType();
+            if (baseObject is string || baseObject is Include || baseType.IsValueType)
+                return false;
+
+            var s = new SerializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeInspector(inspector => new PSObjectTypeInspector(inspector))
+                .Build();
+
+            content = new StringContent(s.Serialize(input), info);
+            return true;
+        }
+
+        private static bool TryConvertScriptBlock(object input, string info, out StringContent content)
+        {
+            content = null;
+            if (!(input is ScriptBlock s))
+                return false;
+
+            content = new StringContent(s.ToString(), info ?? Info_ScriptBlock);
+            return true;
+        }
+
+        private static bool TryConvertString(object input, string info, out StringContent content)
+        {
+            content = null;
+            if (input == null)
+                return false;
+
+            content = new StringContent(input.ToString(), info);
+            return true;
+        }
+
+        private static bool IsYaml(string info)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals("yaml", info) ||
+                StringComparer.OrdinalIgnoreCase.Equals("yml", info);
+        }
+
+        private static bool IsJson(string info)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals("json", info);
         }
     }
 }

--- a/src/PSDocs/Commands/Keyword.cs
+++ b/src/PSDocs/Commands/Keyword.cs
@@ -69,7 +69,7 @@ namespace PSDocs.Commands
         protected static bool TryBool(object o, out bool value)
         {
             value = false;
-            if (GetBaseObject(o) is bool result)
+            if (ObjectHelper.GetBaseObject(o) is bool result)
             {
                 value = result;
                 return true;
@@ -80,17 +80,12 @@ namespace PSDocs.Commands
         protected static bool TryString(object o, out string value)
         {
             value = null;
-            if (GetBaseObject(o) is string result)
+            if (ObjectHelper.GetBaseObject(o) is string result)
             {
                 value = result;
                 return true;
             }
             return false;
-        }
-
-        private static object GetBaseObject(object o)
-        {
-            return o is PSObject pso ? pso.BaseObject : o;
         }
     }
 }

--- a/src/PSDocs/Common/DictionaryExtensions.cs
+++ b/src/PSDocs/Common/DictionaryExtensions.cs
@@ -19,7 +19,7 @@ namespace PSDocs
         public static bool TryPopValue<T>(this IDictionary<string, object> dictionary, string key, out T value)
         {
             value = default;
-            if (TryPopValue(dictionary, key, out object v) && GetBaseObject(v) is T result)
+            if (TryPopValue(dictionary, key, out object v) && ObjectHelper.GetBaseObject(v) is T result)
             {
                 value = result;
                 return true;
@@ -54,7 +54,7 @@ namespace PSDocs
             if (!TryPopValue(dictionary, key, out object result))
                 return false;
 
-            var o = GetBaseObject(result);
+            var o = ObjectHelper.GetBaseObject(result);
             value = o.GetType().IsArray ? ((object[])o).OfType<string>().ToArray() : new string[] { o.ToString() };
             return true;
         }
@@ -80,11 +80,6 @@ namespace PSDocs
             foreach (var kv in values)
                 if (!dictionary.ContainsKey(kv.Key))
                     dictionary.Add(kv.Key, kv.Value);
-        }
-
-        private static object GetBaseObject(object o)
-        {
-            return o is PSObject pso ? pso.BaseObject : o;
         }
     }
 }

--- a/src/PSDocs/Common/ObjectHelper.cs
+++ b/src/PSDocs/Common/ObjectHelper.cs
@@ -1,0 +1,13 @@
+﻿
+using System.Management.Automation;
+
+namespace PSDocs
+{
+    internal static class ObjectHelper
+    {
+        public static object GetBaseObject(object o)
+        {
+            return o is PSObject pso && pso.BaseObject != null ? pso.BaseObject : o;
+        }
+    }
+}

--- a/src/PSDocs/Common/PSObjectExtensions.cs
+++ b/src/PSDocs/Common/PSObjectExtensions.cs
@@ -1,0 +1,21 @@
+﻿
+using System.Management.Automation;
+
+namespace PSDocs
+{
+    internal static class PSObjectExtensions
+    {
+        /// <summary>
+        /// Determines if the PSObject has any note properties.
+        /// </summary>
+        public static bool HasNoteProperty(this PSObject o)
+        {
+            foreach (var property in o.Properties)
+            {
+                if (property.MemberType == PSMemberTypes.NoteProperty)
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/PSDocs/Common/YamlConverters.cs
+++ b/src/PSDocs/Common/YamlConverters.cs
@@ -1,9 +1,13 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Management.Automation;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.TypeInspectors;
+using YamlDotNet.Serialization.TypeResolvers;
 
 namespace PSDocs
 {
@@ -35,6 +39,83 @@ namespace PSDocs
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    internal sealed class PSObjectTypeInspector : TypeInspectorSkeleton
+    {
+        private readonly ITypeInspector _Parent;
+        private readonly ITypeResolver _TypeResolver;
+        private readonly INamingConvention _NamingConvention;
+
+        public PSObjectTypeInspector(ITypeInspector typeInspector)
+        {
+            _Parent = typeInspector;
+            _TypeResolver = new StaticTypeResolver();
+            _NamingConvention = CamelCaseNamingConvention.Instance;
+        }
+
+        public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+        {
+            if (container is PSObject pso)
+                return GetPropertyDescriptor(pso);
+
+            return _Parent.GetProperties(type, container);
+        }
+
+        private IEnumerable<IPropertyDescriptor> GetPropertyDescriptor(PSObject pso)
+        {
+            foreach (var prop in pso.Properties)
+            {
+                if (prop.IsGettable && prop.IsInstance)
+                    yield return new Property(prop, _TypeResolver, _NamingConvention);
+            }
+        }
+
+        private sealed class Property : IPropertyDescriptor
+        {
+            private readonly PSPropertyInfo _PropertyInfo;
+            private readonly Type _PropertyType;
+            private readonly ITypeResolver _TypeResolver;
+            private readonly INamingConvention _NamingConvention;
+
+            public Property(PSPropertyInfo propertyInfo, ITypeResolver typeResolver, INamingConvention namingConvention)
+            {
+                _PropertyInfo = propertyInfo;
+                _PropertyType = propertyInfo.Value.GetType();
+                _TypeResolver = typeResolver;
+                _NamingConvention = namingConvention;
+                ScalarStyle = ScalarStyle.Any;
+            }
+
+            string IPropertyDescriptor.Name => _NamingConvention.Apply(_PropertyInfo.Name);
+
+            public Type Type => _PropertyType;
+
+            public Type TypeOverride { get; set; }
+
+            int IPropertyDescriptor.Order { get; set; }
+
+            bool IPropertyDescriptor.CanWrite => false;
+
+            public ScalarStyle ScalarStyle { get; set; }
+
+            public T GetCustomAttribute<T>() where T : Attribute
+            {
+                return default;
+            }
+
+            void IPropertyDescriptor.Write(object target, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            IObjectDescriptor IPropertyDescriptor.Read(object target)
+            {
+                var propertyValue = _PropertyInfo.Value;
+                var actualType = TypeOverride ?? _TypeResolver.Resolve(Type, propertyValue);
+                return new ObjectDescriptor(propertyValue, actualType, Type, ScalarStyle);
+            }
         }
     }
 }

--- a/src/PSDocs/Pipeline/Execeptions.cs
+++ b/src/PSDocs/Pipeline/Execeptions.cs
@@ -158,4 +158,48 @@ namespace PSDocs.Pipeline
             base.GetObjectData(info, context);
         }
     }
+
+    /// <summary>
+    /// A serialization exception.
+    /// </summary>
+    [Serializable]
+    public sealed class PipelineSerializationException : PipelineException
+    {
+        /// <summary>
+        /// Creates a serialization exception.
+        /// </summary>
+        public PipelineSerializationException()
+        {
+        }
+
+        /// <summary>
+        /// Creates a serialization exception.
+        /// </summary>
+        /// <param name="message">The detail of the exception.</param>
+        public PipelineSerializationException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Creates a serialization exception.
+        /// </summary>
+        /// <param name="message">The detail of the exception.</param>
+        /// <param name="innerException">A nested exception that caused the issue.</param>
+        public PipelineSerializationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        private PipelineSerializationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            base.GetObjectData(info, context);
+        }
+    }
 }

--- a/src/PSDocs/Resources/PSDocsResources.Designer.cs
+++ b/src/PSDocs/Resources/PSDocsResources.Designer.cs
@@ -97,6 +97,15 @@ namespace PSDocs.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Read JSON failed..
+        /// </summary>
+        internal static string ReadJsonFailed {
+            get {
+                return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [PSDocs][D] -- Scanning for source files in module: {0}.
         /// </summary>
         internal static string ScanModule {
@@ -120,6 +129,15 @@ namespace PSDocs.Resources {
         internal static string ScriptNotFound {
             get {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can not serialize a null PSObject..
+        /// </summary>
+        internal static string SerializeNullPSObject {
+            get {
+                return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
         

--- a/src/PSDocs/Resources/PSDocsResources.resx
+++ b/src/PSDocs/Resources/PSDocsResources.resx
@@ -130,6 +130,9 @@
     <value>Options file does not exist.</value>
     <comment>Occurs when explicit path to a YAML file is specified and doesn't exist.</comment>
   </data>
+  <data name="ReadJsonFailed" xml:space="preserve">
+    <value>Read JSON failed.</value>
+  </data>
   <data name="ScanModule" xml:space="preserve">
     <value>[PSDocs][D] -- Scanning for source files in module: {0}</value>
   </data>
@@ -138,6 +141,9 @@
   </data>
   <data name="ScriptNotFound" xml:space="preserve">
     <value>The script was not found.</value>
+  </data>
+  <data name="SerializeNullPSObject" xml:space="preserve">
+    <value>Can not serialize a null PSObject.</value>
   </data>
   <data name="ShouldCreatePath" xml:space="preserve">
     <value>Create path</value>

--- a/src/PSDocs/Runtime/StringContent.cs
+++ b/src/PSDocs/Runtime/StringContent.cs
@@ -8,10 +8,13 @@ namespace PSDocs.Runtime
     {
         private readonly string _Input;
 
-        public StringContent(string input)
+        public StringContent(string input, string info = null)
         {
             _Input = input;
+            Info = info;
         }
+
+        public string Info { get; }
 
         internal string[] ReadLines()
         {

--- a/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
@@ -34,6 +34,7 @@ Document 'BlockQuoteInfoMarkdown' {
 #region Code
 
 Document 'CodeMarkdown' {
+    'Begin'
     Code {
         # This is a comment
         This is code
@@ -41,20 +42,41 @@ Document 'CodeMarkdown' {
         # Another comment
         And code
     }
+    'End'
 }
 
 Document 'CodeMarkdownNamedFormat' {
+    'Begin'
     Code powershell {
         Get-Content
     }
+    'End'
 }
 
 Document 'CodeMarkdownEval' {
+    'Begin'
     $a = 1; $a += 1; $a | Code powershell;
+    'End'
 }
 
 Document 'CodeInclude' {
+    'Begin'
     Include 'psdocs.yml' -BaseDirectory $PSScriptRoot | Code 'yaml'
+    'End'
+}
+
+Document 'CodeJson' {
+    $a = [PSCustomObject]@{
+        Name = 'Value'
+    }
+    $a | Code 'json'
+}
+
+Document 'CodeYaml' {
+    $a = [PSCustomObject]@{
+        Name = 'Value'
+    }
+    $a | Code 'yaml'
 }
 
 #endregion Code

--- a/tests/PSDocs.Tests/PSDocs.Code.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Code.Tests.ps1
@@ -13,6 +13,7 @@ Set-StrictMode -Version latest;
 $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSDocs) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
+$nl = [System.Environment]::NewLine;
 
 Describe 'PSDocs -- Code keyword' -Tag Code {
     $docFilePath = Join-Path -Path $here -ChildPath 'FromFile.Keyword.Doc.ps1';
@@ -28,19 +29,27 @@ Describe 'PSDocs -- Code keyword' -Tag Code {
         }
         It 'Should have generated output' {
             $result = Invoke-PSDocument @invokeParams -Name 'CodeMarkdown';
-            $result | Should -Match "``````$([System.Environment]::NewLine)`# This is a comment$([System.Environment]::NewLine)This is code$([System.Environment]::NewLine)$([System.Environment]::NewLine)`# Another comment$([System.Environment]::NewLine)And code$([System.Environment]::NewLine)``````";
+            $result | Should -Match "Begin$($nl)$($nl)``````powershell$($nl)`# This is a comment$($nl)This is code$($nl)$($nl)`# Another comment$($nl)And code$($nl)``````$($nl)$($nl)End";
         }
         It 'Code markdown with named format' {
             $result = Invoke-PSDocument @invokeParams -Name 'CodeMarkdownNamedFormat';
-            $result | Should -Match "``````powershell$([System.Environment]::NewLine)Get-Content$([System.Environment]::NewLine)``````";
+            $result | Should -Match "Begin$($nl)$($nl)``````powershell$($nl)Get-Content$($nl)``````$($nl)$($nl)End";
         }
         It 'Code markdown with evaluation' {
             $result = Invoke-PSDocument @invokeParams -Name 'CodeMarkdownEval';
-            $result | Should -Match "``````powershell$([System.Environment]::NewLine)2$([System.Environment]::NewLine)``````";
+            $result | Should -Match "Begin$($nl)$($nl)``````powershell$($nl)2$($nl)``````$($nl)$($nl)End";
         }
         It 'Code markdown with include' {
             $result = Invoke-PSDocument @invokeParams -Name 'CodeInclude';
-            $result | Should -Match "``````yaml$([System.Environment]::NewLine)generator: PSDocs$([System.Environment]::NewLine)``````";
+            $result | Should -Match "Begin$($nl)$($nl)``````yaml$($nl)generator: PSDocs$($nl)``````$($nl)$($nl)End";
+        }
+        It 'Code markdown with JSON conversion' {
+            $result = Invoke-PSDocument @invokeParams -Name 'CodeJson';
+            $result | Should -Match "``````json$($nl){$($nl)    `"Name`": `"Value`"$($nl)}$($nl)``````";
+        }
+        It 'Code markdown with YAML conversion' {
+            $result = Invoke-PSDocument @invokeParams -Name 'CodeYaml';
+            $result | Should -Match "``````yaml$($nl)name: Value$($nl)``````";
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Automatically serialize `Code` objects to JSON and YAML. #93
    - Use the `json`, `yaml`, or `yml` info strings to automatically serialize custom objects.
- Default the info string to `powershell` for `Code` script blocks. #92

Fixes #92 
Fixes #93 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
