### PR TITLE
Fixed error action of include keyword #127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ What's changed since v0.7.0:
 - Engine features:
   - Added support for custom configuration key values. [#121](https://github.com/BernieWhite/PSDocs/issues/121)
     - See `about_PSDocs_Configuration` for more details.
+- Bug fixes:
+  - Fixed use of error action preference with `Include` keyword. [#127](https://github.com/BernieWhite/PSDocs/issues/127)
 
 ## v0.7.0
 

--- a/src/PSDocs/Commands/IncludeCommand.cs
+++ b/src/PSDocs/Commands/IncludeCommand.cs
@@ -1,6 +1,8 @@
 ﻿
 using PSDocs.Models;
+using PSDocs.Resources;
 using PSDocs.Runtime;
+using System.IO;
 using System.Management.Automation;
 
 namespace PSDocs.Commands
@@ -29,7 +31,18 @@ namespace PSDocs.Commands
 
         protected override void EndProcessing()
         {
-            WriteObject(ModelHelper.Include(BaseDirectory, Culture, FileName, UseCulture));
+            var result = ModelHelper.Include(BaseDirectory, Culture, FileName, UseCulture);
+            if (result == null || !result.Exists)
+            {
+                WriteError(new ErrorRecord(
+                    exception: new FileNotFoundException(PSDocsResources.IncludeNotFound, result.Path),
+                    errorId: "PSDocs.Runtime.IncludeNotFound",
+                    errorCategory: ErrorCategory.ObjectNotFound,
+                    targetObject: result.Path
+                ));
+                return;
+            }
+            WriteObject(result);            
         }
     }
 }

--- a/src/PSDocs/Models/Include.cs
+++ b/src/PSDocs/Models/Include.cs
@@ -1,13 +1,27 @@
 ﻿
+using System.IO;
+
 namespace PSDocs.Models
 {
     public sealed class Include : DocumentNode
     {
+        private string _Path;
+
         public override DocumentNodeType Type => DocumentNodeType.Include;
 
-        public string Path { get; set; }
+        public string Path
+        {
+            get { return _Path; }
+            set
+            {
+                _Path = value;
+                Exists = File.Exists(_Path);
+            }
+        }
 
         public string Content { get; set; }
+
+        internal bool Exists { get; private set; }
 
         public override string ToString()
         {

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -1,6 +1,5 @@
 ﻿
 using PSDocs.Configuration;
-using PSDocs.Resources;
 using System.IO;
 
 namespace PSDocs.Models
@@ -55,15 +54,16 @@ namespace PSDocs.Models
         {
             baseDirectory = PSDocumentOption.GetRootedPath(baseDirectory);
             var absolutePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(baseDirectory, (useCulture ? culture : string.Empty), fileName);
-            if (!File.Exists(absolutePath))
-                throw new FileNotFoundException(PSDocsResources.IncludeNotFound, absolutePath);
-
-            var text = File.ReadAllText(absolutePath);
-            return new Include
+            var result = new Include
             {
-                Path = absolutePath,
-                Content = text,
+                Path = absolutePath
             };
+            if (result.Exists)
+            {
+                var text = File.ReadAllText(absolutePath);
+                result.Content = text;
+            }
+            return result;
         }
     }
 }

--- a/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
@@ -96,6 +96,16 @@ Document 'IncludeCulture' {
     Include IncludeFile3.md -UseCulture -BaseDirectory tests/PSDocs.Tests/
 }
 
+# Synopsis: Test Include keyword with -ErrorAction SilentlyContinue
+Document 'IncludeOptional' {
+    Include 'NotFile.md' -ErrorAction SilentlyContinue;
+}
+
+# Synopsis: Test Include keyword with missing file
+Document 'IncludeRequired' {
+    Include 'NotFile.md';
+}
+
 #endregion Include
 
 #region Metadata

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -18,7 +18,6 @@ $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSDocs.Tests/Includ
 Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
 $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
-$dummyObject = New-Object -TypeName PSObject;
 
 Describe 'PSDocs -- Include keyword' -Tag Include {
     $docFilePath = Join-Path -Path $here -ChildPath 'FromFile.Keyword.Doc.ps1';
@@ -27,12 +26,12 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
         $invokeParams = @{
             Path = $docFilePath
             OutputPath = $outputPath
-            # PassThru = $True
+            ErrorAction = [System.Management.Automation.ActionPreference]::Stop
         }
 
         It 'Should include a relative path' {
             $outputDoc = "$outputPath\IncludeRelative.md";
-            $result = Invoke-PSDocument @invokeParams -InputObject $rootPath -Name 'IncludeRelative';
+            $Null = Invoke-PSDocument @invokeParams -InputObject $rootPath -Name 'IncludeRelative';
 
             Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';
@@ -41,14 +40,14 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
 
         It 'Should include an absolute path' {
             $outputDoc = "$outputPath\IncludeAbsolute.md";
-            $result = Invoke-PSDocument @invokeParams -InputObject $rootPath -Name 'IncludeAbsolute';
+            $Null = Invoke-PSDocument @invokeParams -InputObject $rootPath -Name 'IncludeAbsolute';
 
             Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is included from an external file.';
         }
 
         It 'Should include from culture' {
-            $result = Invoke-PSDocument @invokeParams -Culture 'en-AU','en-US' -Name 'IncludeCulture';
+            $Null = Invoke-PSDocument @invokeParams -Culture 'en-AU','en-US' -Name 'IncludeCulture';
 
             $outputDoc = "$outputPath\en-AU\IncludeCulture.md";
             Test-Path -Path $outputDoc | Should -Be $True;
@@ -57,6 +56,11 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
             $outputDoc = "$outputPath\en-US\IncludeCulture.md";
             Test-Path -Path $outputDoc | Should -Be $True;
             $outputDoc | Should -FileContentMatch 'This is en-US.';
+        }
+
+        It 'Should include when file exists' {
+            $Null = Invoke-PSDocument @invokeParams -Name 'IncludeOptional';
+            { $Null = Invoke-PSDocument @invokeParams -Name 'IncludeRequired'; } | Should -Throw -Because 'PSDocs.Runtime.IncludeNotFound';
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed use of error action preference with `Include` keyword. #127

Fixes #127 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
