### PR TITLE
Allow tokens to be replaced in included file #134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.8.0-B2101006:
+
+- General improvements:
+  - Added `-Replace` parameter to `Include` keyword to replace tokens in included file. [#134](https://github.com/BernieWhite/PSDocs/issues/134)
+    - A hashtable of replacement tokens can be specified to replace contents within original file.
+    - See `about_PSDocs_Keywords` for more details.
+
 ## v0.8.0-B2101006 (pre-release)
 
 What's changed since v0.7.0:

--- a/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
+++ b/docs/keywords/PSDocs/en-US/about_PSDocs_Keywords.md
@@ -551,13 +551,15 @@ Insert content from an external file into this document.
 Syntax:
 
 ```text
-Include [-FileName] <String> [-BaseDirectory <String>] [-UseCulture]
+Include [-FileName] <String> [-BaseDirectory <String>] [-UseCulture] [-Replace <Hashtable>]
 ```
 
 - `FileName` - The path to a markdown file to include. An absolute or relative path is accepted.
 - `BaseDirectory` - The base path to work from for relative paths specified with the `FileName` parameter.
 By default this is the current working path.
 - `UseCulture` - When specified include will look for the file within a subdirectory for a named culture.
+- `Replace` - When specified include will replace keys occurring in the file with the specified value.
+Replacement keys are case-sensitive.
 
 Examples:
 
@@ -595,6 +597,20 @@ Document 'Sample' {
 
 ```text
 This is included from an external file.
+```
+
+```powershell
+# A document definition
+Document 'Sample' {
+    # Include IncludeFile.md replacing 'included' with 'an example'
+    Include IncludeFile.md -Replace @{
+        'included' = 'an example'
+    }
+}
+```
+
+```text
+This is an example from an external file.
 ```
 
 ## EXAMPLES

--- a/src/PSDocs/Commands/IncludeCommand.cs
+++ b/src/PSDocs/Commands/IncludeCommand.cs
@@ -2,6 +2,7 @@
 using PSDocs.Models;
 using PSDocs.Resources;
 using PSDocs.Runtime;
+using System.Collections;
 using System.IO;
 using System.Management.Automation;
 
@@ -23,6 +24,9 @@ namespace PSDocs.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter UseCulture { get; set; }
 
+        [Parameter(Mandatory = false)]
+        public IDictionary Replace { get; set; }
+
         protected override void BeginProcessing()
         {
             if (string.IsNullOrEmpty(Culture))
@@ -31,7 +35,7 @@ namespace PSDocs.Commands
 
         protected override void EndProcessing()
         {
-            var result = ModelHelper.Include(BaseDirectory, Culture, FileName, UseCulture);
+            var result = ModelHelper.Include(BaseDirectory, Culture, FileName, UseCulture, Replace);
             if (result == null || !result.Exists)
             {
                 WriteError(new ErrorRecord(

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -1,5 +1,6 @@
 ﻿
 using PSDocs.Configuration;
+using System.Collections;
 using System.IO;
 
 namespace PSDocs.Models
@@ -52,6 +53,11 @@ namespace PSDocs.Models
 
         public static Include Include(string baseDirectory, string culture, string fileName, bool useCulture)
         {
+            return Include(baseDirectory, culture, fileName, useCulture, null);
+        }
+
+        internal static Include Include(string baseDirectory, string culture, string fileName, bool useCulture, IDictionary replace)
+        {
             baseDirectory = PSDocumentOption.GetRootedPath(baseDirectory);
             var absolutePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(baseDirectory, (useCulture ? culture : string.Empty), fileName);
             var result = new Include
@@ -61,6 +67,15 @@ namespace PSDocs.Models
             if (result.Exists)
             {
                 var text = File.ReadAllText(absolutePath);
+                if (replace != null && replace.Count > 0)
+                {
+                    foreach (var key in replace.Keys)
+                    {
+                        var k = key?.ToString();
+                        var v = replace[key]?.ToString();
+                        text = text.Replace(k, v);
+                    }
+                }
                 result.Content = text;
             }
             return result;

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -521,7 +521,10 @@ function Include {
         [String]$Culture = $Culture,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$UseCulture = $False
+        [Switch]$UseCulture = $False,
+
+        [Parameter(Mandatory = $False)]
+        [System.Collections.IDictionary]$Replace
     )
     begin {
         # This is just a stub to improve authoring and discovery

--- a/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Keyword.Doc.ps1
@@ -106,6 +106,13 @@ Document 'IncludeRequired' {
     Include 'NotFile.md';
 }
 
+# Synopsis: Include and replace tokens
+Document 'IncludeReplace' {
+    Include IncludeFile2.md -BaseDirectory $PSScriptRoot -Replace @{
+        'second' = 'third'
+    }
+}
+
 #endregion Include
 
 #region Metadata

--- a/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Include.Tests.ps1
@@ -62,5 +62,10 @@ Describe 'PSDocs -- Include keyword' -Tag Include {
             $Null = Invoke-PSDocument @invokeParams -Name 'IncludeOptional';
             { $Null = Invoke-PSDocument @invokeParams -Name 'IncludeRequired'; } | Should -Throw -Because 'PSDocs.Runtime.IncludeNotFound';
         }
+
+        It 'Should replace tokens' {
+            $result = Invoke-PSDocument @invokeParams -Name 'IncludeReplace' -PassThru;
+            $result | Should -BeLike 'This is a third file to include.*'
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- Added `-Replace` parameter to `Include` keyword to replace tokens in included file.
  - A hashtable of replacement tokens can be specified to replace contents within original file.
  - See `about_PSDocs_Keywords` for more details.

Fixes #134 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
