### PR TITLE
Fixed boolean string with GetBoolOrDefault #140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.8.0-B2101011:
+
+- Bug fixes:
+  - Fixed boolean string conversion with the `GetBoolOrDefault` configuration helper. [#140](https://github.com/BernieWhite/PSDocs/issues/140)
+
 ## v0.8.0-B2101011 (pre-release)
 
 What's changed since pre-release v0.8.0-B2101006:
@@ -145,13 +150,16 @@ What's changed since v0.5.0:
   - Added support for locked down environments to ensure that documents are executed as constrained code when Device Guard is used.
     - Use the `Execution.LanguageMode = 'ConstrainedLanguage'` option to force constrained language mode.
   - **Important change**: Improved markdown formatting for tables. [#31](https://github.com/BernieWhite/PSDocs/issues/31)
-    - Table columns are now padded by default to match header width. Set `Markdown.ColumnPadding` option to `None` to match format style from PSDocs <= 0.5.0.
-    - Pipe characters on the start and end of a table row are not added by default. Set `Markdown.UseEdgePipes` option to `Always` to match format style from PSDocs <= 0.5.0.
+    - Table columns are now padded by default to match header width.
+    Set `Markdown.ColumnPadding` option to `None` to match format style from PSDocs <= 0.5.0.
+    - Pipe characters on the start and end of a table row are not added by default.
+    Set `Markdown.UseEdgePipes` option to `Always` to match format style from PSDocs <= 0.5.0.
     - Property expressions now support Label, Expression, Alignment and Width keys.
   - **Experimental**: Publishing of keywords for syntax completion with editors.
 - Deprecations and removals:
   - **Breaking change**: Removed `Import-PSDocumentTemplate` cmdlet. Use `Invoke-PSDocument` instead or dot source.
-  - **Breaking change**: Removed support for `-Function` parameter of `Invoke-PSDocument`. External commands can be executed in document blocks. Re-evaluating if this is really needed.
+  - **Breaking change**: Removed support for `-Function` parameter of `Invoke-PSDocument`.
+  External commands can be executed in document blocks. Re-evaluating if this is really needed.
   - **Important change**: Renamed `-When` parameter on Section block to `-If`.
     - This provides a shorter parameter and more clearly describes the intent of the parameter.
     - `-When` is still works but is deprecated.
@@ -187,7 +195,8 @@ What's changed since v0.3.0:
   - Added `New-PSDocumentOption` cmdlet to configure document generation.
   - Added `-Option` parameter to `Invoke-PSDocument` cmdlet to accept configuration options.
 - General improvements:
-  - **Important change**: Renamed `Yaml` keyword to `Metadata`. `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead.
+  - **Important change**: Renamed `Yaml` keyword to `Metadata`.
+  `Yaml` keyword is still supported but deprecated, switch to using `Metadata` instead.
   - **Breaking change**: Added support for encoding markdown content output. [#16](https://github.com/BernieWhite/PSDocs/issues/16)
     - To specify the encoding use the `-Encoding` parameter of `Invoke-PSDocument` and `Invoke-DscNodeDocument`.
     - Output now defaults to UTF-8 without byte order mark (BOM) instead of ASCII.

--- a/src/PSDocs/Runtime/Configuration.cs
+++ b/src/PSDocs/Runtime/Configuration.cs
@@ -59,7 +59,7 @@ namespace PSDocs.Runtime
 
         public bool GetBoolOrDefault(string configurationKey, bool defaultValue)
         {
-            if (!TryGetValue(configurationKey, out object value) || !(value is bool bvalue))
+            if (!TryGetValue(configurationKey, out object value) || !TryBool(value, out bool bvalue))
                 return defaultValue;
 
             return bvalue;
@@ -72,6 +72,17 @@ namespace PSDocs.Runtime
                 return false;
 
             return _Context.Pipeline.Option.Configuration.TryGetValue(name, out value);
+        }
+
+        private bool TryBool(object o, out bool value)
+        {
+            value = default(bool);
+            if (o is bool bvalue || (o is string svalue && bool.TryParse(svalue, out bvalue)))
+            {
+                value = bvalue;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/tests/PSDocs.Tests/FromFile.Variables.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Variables.Doc.ps1
@@ -15,6 +15,9 @@ Document 'PSDocsVariable' {
     if ($PSDocs.Configuration.GetBoolOrDefault('NotConfig', $True)) {
         "Document.Metadata=$($Document.Metadata['author']);"
     }
+    if ($PSDocs.Configuration.GetBoolOrDefault('Enabled', $True)) {
+        "Document.Enabled=true"
+    }
 }
 
 # Synopsis: Test $Document variable

--- a/tests/PSDocs.Tests/PSDocs.Options.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Options.Tests.ps1
@@ -38,14 +38,16 @@ Describe 'New-PSDocumentOption' -Tag 'Option' {
         }
 
         It 'from Hashtable' {
-            $option = New-PSDocumentOption -Option @{ 'Configuration.Key1' = 'Value1' };
+            $option = New-PSDocumentOption -Option @{ 'Configuration.Key1' = 'Value1'; 'Configuration.BoolValue' = $True };
             $option.Configuration.Key1 | Should -Be 'Value1';
+            $option.Configuration.BoolValue | Should -Be $True;
         }
 
         It 'from YAML' {
             $option = New-PSDocumentOption -Option (Join-Path -Path $here -ChildPath 'PSDocs.Tests.yml');
             $option.Configuration.Key1 | Should -Be 'Value2';
-            $option.Configuration.'UnitTests.String.1' | Should -Be 'Config string 1'
+            $option.Configuration.'UnitTests.String.1' | Should -Be 'Config string 1';
+            $option.Configuration.'UnitTests.Bool.1' | Should -Be $True;
         }
     }
 

--- a/tests/PSDocs.Tests/PSDocs.Tests.yml
+++ b/tests/PSDocs.Tests/PSDocs.Tests.yml
@@ -3,6 +3,7 @@
 configuration:
   Key1: Value2
   UnitTests.String.1: Config string 1
+  UnitTests.Bool.1: true
 
 markdown:
   encoding: UTF8

--- a/tests/PSDocs.Tests/PSDocs.Variables.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Variables.Tests.ps1
@@ -41,12 +41,14 @@ Describe 'PSDocs variables' -Tag 'Variables' {
             PassThru = $True
             Option = @{
                 'Configuration.author' = @{ name = 'unit-tester' }
+                'Configuration.enabled' = 'faLse'
             }
         }
         It '$PSDocs' {
             $result = (Invoke-PSDocument @invokeParams -Name 'PSDocsVariable' | Out-String).Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries);
             $result | Where-Object -FilterScript { $_ -like "TargetObject.Name=*" } | Should -Be 'TargetObject.Name=TestObject;';
             $result | Where-Object -FilterScript { $_ -like "Document.Metadata=*" } | Should -Be 'Document.Metadata=unit-tester;';
+            $result | Where-Object -FilterScript { $_ -like "Document.Enabled=*" } | Should -BeNullOrEmpty;
         }
         It '$Document' {
             $result = (Invoke-PSDocument @invokeParams -Name 'PSDocsDocumentVariable' | Out-String).Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries);


### PR DESCRIPTION
## PR Summary

- Fixed boolean string conversion with the `GetBoolOrDefault` configuration helper. #140

Fixes #140 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
