### PR TITLE
Added support for conventions #18 #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 What's changed since pre-release v0.8.0-B2101011:
 
+- Engine features:
+  - Added support for running custom actions using conventions. [#18](https://github.com/BernieWhite/PSDocs/issues/18)
+  [#120](https://github.com/BernieWhite/PSDocs/issues/120)
+    - Conventions provide `Begin`, `Process` and `End` blocks to hook into the document pipeline.
+    - Name or change the output path of documents in `Begin` and `Process` blocks.
+    - Generate table of contents (TOC) and perform publishing actions in `End` blocks.
+    - See [about_PSDocs_Conventions] for more details.
 - Bug fixes:
   - Fixed boolean string conversion with the `GetBoolOrDefault` configuration helper. [#140](https://github.com/BernieWhite/PSDocs/issues/140)
 
@@ -14,7 +21,7 @@ What's changed since pre-release v0.8.0-B2101006:
 - General improvements:
   - Added `-Replace` parameter to `Include` keyword to replace tokens in included file. [#134](https://github.com/BernieWhite/PSDocs/issues/134)
     - A hashtable of replacement tokens can be specified to replace contents within original file.
-    - See `about_PSDocs_Keywords` for more details.
+    - See [about_PSDocs_Keywords] for more details.
 
 ## v0.8.0-B2101006 (pre-release)
 
@@ -22,7 +29,7 @@ What's changed since v0.7.0:
 
 - Engine features:
   - Added support for custom configuration key values. [#121](https://github.com/BernieWhite/PSDocs/issues/121)
-    - See `about_PSDocs_Configuration` for more details.
+    - See [about_PSDocs_Configuration] for more details.
 - General improvements:
   - Improve handling when an empty document title is set. [#122](https://github.com/BernieWhite/PSDocs/issues/122)
 - Bug fixes:
@@ -38,12 +45,12 @@ What's changed since v0.6.3:
   - Added support for localized strings using the `$LocalizedData` variable. [#91](https://github.com/BernieWhite/PSDocs/issues/91)
   - Automatically serialize `Code` objects to JSON and YAML. [#93](https://github.com/BernieWhite/PSDocs/issues/93)
     - Use the `json`, `yaml`, or `yml` info strings to automatically serialize custom objects.
-    - See `about_PSDocs_Keywords` for more details.
+    - See [about_PSDocs_Keywords] for more details.
 - General improvements:
   - Added configuration for setting output options. [#105](https://github.com/BernieWhite/PSDocs/issues/105)
   - Added parameter alias `-MarkdownEncoding` on `New-PSDocumentOption` for `-Encoding`. [#106](https://github.com/BernieWhite/PSDocs/issues/106)
   - Default the info string to `powershell` for `Code` script blocks. [#92](https://github.com/BernieWhite/PSDocs/issues/92)
-    - See `about_PSDocs_Keywords` for more details.
+    - See [about_PSDocs_Keywords] for more details.
 - Deprecations and removals:
   - Added [upgrade notes](docs/upgrade-notes.md) for migration from v0.6.x to v0.7.0.
   - **Breaking change**: Removed support for inline document blocks.
@@ -74,12 +81,12 @@ What's changed since pre-release v0.7.0-B2008035:
   - Added support for localized strings using the `$LocalizedData` variable. [#91](https://github.com/BernieWhite/PSDocs/issues/91)
   - Automatically serialize `Code` objects to JSON and YAML. [#93](https://github.com/BernieWhite/PSDocs/issues/93)
     - Use the `json`, `yaml`, or `yml` info strings to automatically serialize custom objects.
-    - See `about_PSDocs_Keywords` for more details.
+    - See [about_PSDocs_Keywords] for more details.
 - General improvements:
   - Added configuration for setting output options. [#105](https://github.com/BernieWhite/PSDocs/issues/105)
   - Added parameter alias `-MarkdownEncoding` on `New-PSDocumentOption` for `-Encoding`. [#106](https://github.com/BernieWhite/PSDocs/issues/106)
   - Default the info string to `powershell` for `Code` script blocks. [#92](https://github.com/BernieWhite/PSDocs/issues/92)
-    - See `about_PSDocs_Keywords` for more details.
+    - See [about_PSDocs_Keywords] for more details.
 - Bug fixes:
   - Fixed inconsistencies with default options file name. [#103](https://github.com/BernieWhite/PSDocs/issues/103)
   - Fixed line break after block quote. [#104](https://github.com/BernieWhite/PSDocs/issues/104)
@@ -237,3 +244,7 @@ What's changed since v0.1.0:
 ## v0.1.0
 
 - Initial release.
+
+[about_PSDocs_Configuration]: docs/concepts/PSDocs/en-US/about_PSDocs_Configuration.md
+[about_PSDocs_Conventions]: docs/concepts/PSDocs/en-US/about_PSDocs_Conventions.md
+[about_PSDocs_Keywords]: docs/concepts/PSDocs/en-US/about_PSDocs_Keywords.md

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following conceptual topics exist in the `PSDocs` module:
   - [$Document](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#document)
   - [$InstanceName](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#instancename)
   - [$LocalizedData](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#localizeddata)
+  - [$PSDocs](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#psdocs)
   - [$TargetObject](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#targetobject)
   - [$Section](docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md#section)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following commands exist in the `PSDocs.Dsc` module:
 The following conceptual topics exist in the `PSDocs` module:
 
 - [Configuration](docs/concepts/PSDocs/en-US/about_PSDocs_Configuration.md)
+- [Conventions](docs/concepts/PSDocs/en-US/about_PSDocs_Conventions.md)
 - [Options](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md)
   - [Configuration](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#configuration)
   - [Execution.LanguageMode](docs/concepts/PSDocs/en-US/about_PSDocs_Options.md#executionlanguagemode)

--- a/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
+++ b/docs/commands/PSDocs/en-US/Invoke-PSDocument.md
@@ -16,7 +16,7 @@ Create markdown from an input object.
 ```text
 Invoke-PSDocument [-Module <String[]>] [-Name <String[]>] [-Tag <String[]>] [-InstanceName <String[]>]
  [-InputObject <PSObject>] [[-Path] <String>] [-OutputPath <String>] [-PassThru] [-Option <PSDocumentOption>]
- [-Encoding <MarkdownEncoding>] [-Culture <String[]>] [<CommonParameters>]
+ [-Encoding <MarkdownEncoding>] [-Culture <String[]>] [-Convention <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -265,6 +265,22 @@ Accept wildcard characters: False
 
 A list of cultures for building documents such as _en-AU_, and _en-US_.
 Documents are written to culture specific subdirectories when multiple cultures are generated.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Convention
+
+Specifies the name of conventions to execute during document generation.
 
 ```yaml
 Type: String[]

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Conventions.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Conventions.md
@@ -1,0 +1,138 @@
+# PSDocs_Conventions
+
+## about_PSDocs_Conventions
+
+## SHORT DESCRIPTION
+
+Describes PSDocs Conventions including how to use and author them.
+
+## LONG DESCRIPTION
+
+PSDocs generates documents dynamically from input.
+When generating multiple documents it is often necessary to name or annotate them in a structured manner.
+Conventions achieve this by hooking into the pipeline to trigger custom actions defined in a script block.
+
+### Using conventions
+
+A convention once defined can be included by using the `-Convention` parameter of `Invoke-PSDocument`.
+To use a convention specify the name of the convention by name.
+For example:
+
+```powershell
+Invoke-PSDocument -Convention 'ExampleConvention';
+```
+
+If multiple conventions are specified in an array, all are executed in they are specified.
+As a result, the convention specified last may override state set by earlier conventions.
+
+### Defining conventions
+
+To define a convention, add a `Export-PSDocumentConvention` block within a `.Doc.ps1` file.
+When executed the `.Doc.ps1` must be in an included path or module with `-Path` or `-Module`.
+
+The `Export-PSDocumentConvention` block works similar to the `Document` block.
+Each convention must have a unique name.
+For example:
+
+```powershell
+# Synopsis: An example convention.
+Export-PSDocumentConvention 'ExampleConvention' {
+    # Add code here
+}
+```
+
+### Begin Process End blocks
+
+Conventions define three executable blocks `Begin`, `Process`, `End` similar to a PowerShell function.
+Each block is injected in a different part of the pipeline as follows:
+
+- `Begin` occurs before the document definition is called.
+- `Process` occurs directly after the document definition is called.
+- `End` occurs after all documents have been generated.
+
+Convention block limitations:
+
+- `Begin` can not use document specific variables such as `$Document`.
+- `End` can not use automatic variables except `$PSDocs.Output`.
+
+By default, the `Process` block used.
+For example:
+
+```powershell
+# Synopsis: The default { } executes the process block
+Export-PSDocumentConvention 'ExampleConvention' {
+    # Process block
+}
+
+# Synopsis: With optional -Process parameter name
+Export-PSDocumentConvention 'ExampleConvention' -Process {
+    # Process block
+}
+```
+
+To use `Begin` or `End` explicitly add these blocks.
+For example:
+
+```powershell
+Export-PSDocumentConvention 'ExampleConvention' -Process {
+    # Process block
+} -Begin {
+    # Begin block
+} -End {
+    # End block
+}
+```
+
+### Naming documents
+
+Generated document output files are named based on InstanceName.
+To alter the InstanceName of a document use the `InstanceName` property.
+
+Syntax:
+
+```text
+$PSDocs.Document.InstanceName = value;
+```
+
+For example:
+
+```powershell
+# Synopsis: An example naming convention.
+Export-PSDocumentConvention 'TestNamingConvention1' {
+    $PSDocs.Document.InstanceName = 'NewName';
+}
+```
+
+### Setting output path
+
+Generated document output files are named based on OutputPath.
+To alter the OutputPath of a document use the `OutputPath` property.
+
+Syntax:
+
+```text
+$PSDocs.Document.OutputPath = value;
+```
+
+For example:
+
+```powershell
+# Synopsis: An example naming convention.
+Export-PSDocumentConvention 'TestNamingConvention1' {
+    $newPath = Join-Path -Path $PSDocs.Document.OutputPath -ChildPath 'new';
+    $PSDocs.Document.OutputPath = $newPath;
+}
+```
+
+## NOTE
+
+An online version of this document is available at https://github.com/BernieWhite/PSDocs/blob/main/docs/concepts/PSDocs/en-US/about_PSDocs_Conventions.md.
+
+## SEE ALSO
+
+- [Invoke-PSDocument](https://github.com/BernieWhite/PSDocs/blob/main/docs/commands/PSDocs/en-US/Invoke-PSDocument.md)
+
+## KEYWORDS
+
+- Conventions
+- PSDocs

--- a/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
+++ b/docs/concepts/PSDocs/en-US/about_PSDocs_Variables.md
@@ -148,6 +148,9 @@ Each configuration key specified in `ps-docs.yaml` is assessable as a property.
 Additionally helper methods can be used.
 See `about_PSDocs_Configuration` for more information.
 - `Culture` - The name of the culture currently being processed.
+- `Document` - A document context object.
+- `Output` - All the document results generated.
+This property is only available within `End` convention blocks.
 - `TargetObject` - The value of the pipeline object currently being processed.
 
 Syntax:
@@ -157,13 +160,19 @@ $PSDocs
 ```
 
 ```powershell
-# Get the value of the custom configuration 'Key1'
+# Get the value of the custom configuration 'Key1'.
 $PSDocs.Configuration.Key1
 ```
 
 ```powershell
 # Return the currently processed culture. e.g. 'en-US'
 $PSDocs.Culture
+```
+
+```powershell
+# Access document context properties.
+$PSDocs.Document.InstanceName
+$PSDocs.Document.OutputPath
 ```
 
 ```powershell

--- a/src/PSDocs.Benchmark/PSDocs.cs
+++ b/src/PSDocs.Benchmark/PSDocs.cs
@@ -3,6 +3,7 @@ using PSDocs.Configuration;
 using PSDocs.Models;
 using PSDocs.Pipeline;
 using PSDocs.Processor.Markdown;
+using PSDocs.Runtime;
 using System;
 using System.IO;
 using System.Management.Automation;
@@ -56,7 +57,11 @@ namespace PSDocs.Benchmark
 
         private static Document GetDocument()
         {
-            var result = new Document("test-benchmark", null)
+            var context = new DocumentContext(null)
+            {
+                InstanceName = "test-benchmark"
+            };
+            var result = new Document(context)
             {
                 Title = "Test document"
             };

--- a/src/PSDocs/Commands/DefinitionCommand.cs
+++ b/src/PSDocs/Commands/DefinitionCommand.cs
@@ -40,7 +40,7 @@ namespace PSDocs.Commands
 
             // Create PS instance for execution
             var ps = context.NewPowerShell();
-            ps.AddCommand(new CmdletInfo(InvokeBlockCmdletName, typeof(InvokeBlockCommand)));
+            ps.AddCommand(new CmdletInfo(InvokeBlockCmdletName, typeof(InvokeDocumentCommand)));
             //ps.AddParameter(InvokeBlockCmdlet_TypeParameter, NodeType);
             ps.AddParameter(InvokeBlockCmdlet_BodyParameter, Body);
 

--- a/src/PSDocs/Commands/ExportConventionCommand.cs
+++ b/src/PSDocs/Commands/ExportConventionCommand.cs
@@ -1,0 +1,70 @@
+﻿
+using PSDocs.Definitions.Conventions;
+using PSDocs.Runtime;
+using System;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PSDocs.Commands
+{
+    [Cmdlet(VerbsLifecycle.Register, LanguageKeywords.Convention)]
+    internal sealed class ExportConventionCommand : PSCmdlet
+    {
+        private const string InvokeCmdletName = "Invoke-PSDocumentConvention";
+        private const string InvokeCmdlet_BodyParameter = "Body";
+        private const string InvokeCmdlet_InputObjectParameter = "InputObject";
+
+        /// <summary>
+        /// Convention name.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Begin block.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public ScriptBlock Begin { get; set; }
+
+        /// <summary>
+        /// Process block.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 1)]
+        public ScriptBlock Process { get; set; }
+
+        /// <summary>
+        /// End block.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public ScriptBlock End { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var context = RunspaceContext.CurrentThread;
+            var sourceFile = context.SourceFile;
+
+            // Return convention
+            var result = new ScriptBlockDocumentConvention(
+                source: sourceFile,
+                name: Name,
+                begin: ConventionBlock(context, Begin),
+                process: ConventionBlock(context, Process),
+                end: ConventionBlock(context, End)
+            );
+            WriteObject(result);
+        }
+
+        private static LanguageScriptBlock ConventionBlock(RunspaceContext context, ScriptBlock block)
+        {
+            if (block == null)
+                return null;
+
+            // Create PS instance for execution
+            var ps = context.NewPowerShell();
+            ps.AddCommand(new CmdletInfo(InvokeCmdletName, typeof(InvokeConventionCommand)));
+            ps.AddParameter(InvokeCmdlet_BodyParameter, block);
+            return new LanguageScriptBlock(ps);
+        }
+    }
+}

--- a/src/PSDocs/Commands/InvokeConventionCommand.cs
+++ b/src/PSDocs/Commands/InvokeConventionCommand.cs
@@ -3,8 +3,8 @@ using System.Management.Automation;
 
 namespace PSDocs.Commands
 {
-    [Cmdlet(VerbsLifecycle.Invoke, LanguageKeywords.Block)]
-    internal sealed class InvokeBlockCommand : PSCmdlet
+    [Cmdlet(VerbsLifecycle.Invoke, LanguageKeywords.Convention)]
+    internal sealed class InvokeConventionCommand : PSCmdlet
     {
         [Parameter()]
         public string[] Type;
@@ -15,15 +15,17 @@ namespace PSDocs.Commands
         [Parameter()]
         public ScriptBlock Body;
 
+        [Parameter(ValueFromPipeline = true)]
+        public PSObject InputObject;
+
         protected override void ProcessRecord()
         {
             try
             {
                 if (Body == null)
-                {
                     return;
-                }
-                WriteObject(Body.Invoke(), true);
+
+                WriteObject(Body.Invoke(InputObject), true);
             }
             finally
             {

--- a/src/PSDocs/Commands/InvokeDocumentCommand.cs
+++ b/src/PSDocs/Commands/InvokeDocumentCommand.cs
@@ -1,0 +1,33 @@
+﻿
+using System.Management.Automation;
+
+namespace PSDocs.Commands
+{
+    [Cmdlet(VerbsLifecycle.Invoke, LanguageKeywords.Block)]
+    internal sealed class InvokeDocumentCommand : PSCmdlet
+    {
+        [Parameter()]
+        public string[] Type;
+
+        [Parameter()]
+        public ScriptBlock If;
+
+        [Parameter()]
+        public ScriptBlock Body;
+
+        protected override void ProcessRecord()
+        {
+            try
+            {
+                if (Body == null)
+                    return;
+
+                WriteObject(Body.Invoke(), true);
+            }
+            finally
+            {
+
+            }
+        }
+    }
+}

--- a/src/PSDocs/Commands/Keyword.cs
+++ b/src/PSDocs/Commands/Keyword.cs
@@ -9,6 +9,7 @@ namespace PSDocs.Commands
     internal static class LanguageKeywords
     {
         public const string Definition = "Definition";
+        public const string Convention = "PSDocumentConvention";
         public const string Document = "Document";
         public const string Block = "Block";
         public const string Note = "Note";
@@ -26,8 +27,10 @@ namespace PSDocs.Commands
     internal static class LanguageCmdlets
     {
         public const string NewDefinition = "New-Definition";
+        public const string ExportConvention = "Export-PSDocumentConvention";
         public const string NewSection = "New-Section";
         public const string InvokeBlock = "Invoke-Block";
+        public const string InvokeConvention = "Invoke-PSDocumentConvention";
         public const string FormatCode = "Format-Code";
         public const string FormatBlockQuote = "Format-BlockQuote";
         public const string FormatNote = "Format-Note";

--- a/src/PSDocs/Data/IDocumentBuilder.cs
+++ b/src/PSDocs/Data/IDocumentBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using PSDocs.Models;
+using PSDocs.Processor;
 using PSDocs.Runtime;
 using System;
 using System.Management.Automation;
@@ -10,5 +11,7 @@ namespace PSDocs.Data
         string Name { get; }
 
         Document Process(RunspaceContext context, PSObject sourceObject);
+
+        void End(RunspaceContext context, IDocumentResult[] completed);
     }
 }

--- a/src/PSDocs/Definitions/Conventions/BaseDocumentConvention.cs
+++ b/src/PSDocs/Definitions/Conventions/BaseDocumentConvention.cs
@@ -1,0 +1,31 @@
+﻿
+using PSDocs.Runtime;
+using System.Collections;
+
+namespace PSDocs.Definitions.Conventions
+{
+    internal abstract class BaseDocumentConvention : IDocumentConvention
+    {
+        protected BaseDocumentConvention(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public virtual void Begin(RunspaceContext context, IEnumerable input)
+        {
+
+        }
+
+        public virtual void Process(RunspaceContext context, IEnumerable input)
+        {
+
+        }
+
+        public virtual void End(RunspaceContext context, IEnumerable input)
+        {
+
+        }
+    }
+}

--- a/src/PSDocs/Definitions/Conventions/DefaultDocumentConvention.cs
+++ b/src/PSDocs/Definitions/Conventions/DefaultDocumentConvention.cs
@@ -1,0 +1,25 @@
+﻿
+using PSDocs.Configuration;
+using PSDocs.Runtime;
+using System.Collections;
+using System.IO;
+
+namespace PSDocs.Definitions.Conventions
+{
+    internal sealed class DefaultDocumentConvention : BaseDocumentConvention
+    {
+        internal DefaultDocumentConvention(string name)
+            : base(name) { }
+
+        public override void Process(RunspaceContext context, IEnumerable input)
+        {
+            var culture = context.Builder.Document.Culture;
+            var rootedPath = PSDocumentOption.GetRootedPath(context.Pipeline.Option.Output.Path);
+            var outputPath = !string.IsNullOrEmpty(culture) && context.Pipeline.Option.Output?.Culture?.Length > 1 ?
+                Path.Combine(rootedPath, culture) : rootedPath;
+
+            context.DocumentContext.InstanceName = context.Builder.Document.Name;
+            context.DocumentContext.OutputPath = outputPath;
+        }
+    }
+}

--- a/src/PSDocs/Definitions/Conventions/ScriptBlockDocumentConvention.cs
+++ b/src/PSDocs/Definitions/Conventions/ScriptBlockDocumentConvention.cs
@@ -1,0 +1,63 @@
+﻿
+using PSDocs.Pipeline;
+using PSDocs.Runtime;
+using System.Collections;
+using System.Management.Automation;
+
+namespace PSDocs.Definitions.Conventions
+{
+    internal sealed class ScriptBlockDocumentConvention : BaseDocumentConvention, ILanguageBlock
+    {
+        private readonly LanguageScriptBlock _Begin;
+        private readonly LanguageScriptBlock _Process;
+        private readonly LanguageScriptBlock _End;
+
+        public ScriptBlockDocumentConvention(SourceFile source, string name, LanguageScriptBlock begin, LanguageScriptBlock process, LanguageScriptBlock end)
+            : base(name)
+        {
+            Source = source;
+            Id = ResourceHelper.GetId(source.ModuleName, name);
+            _Begin = begin;
+            _Process = process;
+            _End = end;
+        }
+
+        public string Id { get; }
+
+        public SourceFile Source { get; }
+
+        string ILanguageBlock.Module => Source.ModuleName;
+
+        string ILanguageBlock.SourcePath => Source.Path;
+
+        public override void Begin(RunspaceContext context, IEnumerable input)
+        {
+            InvokeConventionBlock(_Begin, input);
+        }
+
+        public override void Process(RunspaceContext context, IEnumerable input)
+        {
+            InvokeConventionBlock(_Process, input);
+        }
+
+        public override void End(RunspaceContext context, IEnumerable input)
+        {
+            InvokeConventionBlock(_End, input);
+        }
+
+        private void InvokeConventionBlock(LanguageScriptBlock block, IEnumerable input)
+        {
+            if (block == null)
+                return;
+
+            try
+            {
+                block.Invoke();
+            }
+            finally
+            {
+
+            }
+        }
+    }
+}

--- a/src/PSDocs/Definitions/IDocumentConvention.cs
+++ b/src/PSDocs/Definitions/IDocumentConvention.cs
@@ -1,0 +1,17 @@
+﻿
+using PSDocs.Runtime;
+using System.Collections;
+
+namespace PSDocs.Definitions
+{
+    internal interface IDocumentConvention
+    {
+        string Name { get; }
+
+        void Begin(RunspaceContext context, IEnumerable input);
+
+        void Process(RunspaceContext context, IEnumerable input);
+
+        void End(RunspaceContext context, IEnumerable input);
+    }
+}

--- a/src/PSDocs/Models/Document.cs
+++ b/src/PSDocs/Models/Document.cs
@@ -1,25 +1,32 @@
 ﻿
+using PSDocs.Runtime;
+using System.Collections;
 using System.Collections.Specialized;
 
 namespace PSDocs.Models
 {
     public sealed class Document : SectionNode
     {
-        public readonly string Name;
-        public readonly string Culture;
+        internal readonly DocumentContext Context;
 
-        public Document(string name, string culture)
+        internal Document(DocumentContext context)
         {
-            Name = name;
-            Culture = culture;
-            Metadata = new OrderedDictionary();
+            Context = context;
         }
+
+        public string Name => Context?.InstanceName;
+
+        public string Culture => Context?.Culture;
 
         public override DocumentNodeType Type
         {
             get { return DocumentNodeType.Document; }
         }
 
-        public OrderedDictionary Metadata { get; set; }
+        public OrderedDictionary Metadata => Context?.Metadata;
+
+        public Hashtable Data => Context?.Data;
+
+        public string Path => Context?.OutputPath;
     }
 }

--- a/src/PSDocs/Models/ModelHelper.cs
+++ b/src/PSDocs/Models/ModelHelper.cs
@@ -9,7 +9,7 @@ namespace PSDocs.Models
     {
         public static Document NewDocument()
         {
-            return new Document(null, null);
+            return new Document(null);
         }
 
         public static Section NewSection(string name, int level)

--- a/src/PSDocs/PSDocs.psd1
+++ b/src/PSDocs/PSDocs.psd1
@@ -86,13 +86,16 @@ FunctionsToExport = @(
     'Note'
     'Warning'
     'Include'
+    'Export-PSDocumentConvention'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = @()
+VariablesToExport = @(
+    'PSDocs'
+)
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = @()

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -65,7 +65,10 @@ function Invoke-PSDocument {
         [PSDocs.Configuration.MarkdownEncoding]$Encoding = [PSDocs.Configuration.MarkdownEncoding]::Default,
 
         [Parameter(Mandatory = $False)]
-        [String[]]$Culture
+        [String[]]$Culture,
+
+        [Parameter(Mandatory = $False)]
+        [String[]]$Convention
     )
     begin {
         Write-Verbose -Message "[Invoke-PSDocument]::BEGIN";
@@ -134,6 +137,7 @@ function Invoke-PSDocument {
 
         $builder = [PSDocs.Pipeline.PipelineBuilder]::Invoke($sourceFiles, $Option, $PSCmdlet, $ExecutionContext);
         $builder.InstanceName($InstanceName);
+        $builder.Convention($Convention);
         try {
             $pipeline = $builder.Build();
             if ($Null -ne $pipeline) {
@@ -369,6 +373,28 @@ function New-PSDocumentOption {
 #
 
 #region Keywords
+
+function Export-PSDocumentConvention {
+    [CmdletBinding()]
+    [OutputType([void])]
+    param (
+        [Parameter(Position = 0, Mandatory = $True)]
+        [String]$Name,
+
+        [Parameter(Mandatory = $False)]
+        [ScriptBlock]$Begin,
+
+        [Parameter(Position = 1, Mandatory = $True)]
+        [ScriptBlock]$Process,
+
+        [Parameter(Mandatory = $False)]
+        [ScriptBlock]$End
+    )
+    begin {
+         # This is just a stub to improve authoring and discovery
+         Write-Error -Message $LocalizedHelp.KeywordOutsideEngine -Category InvalidOperation;
+    }
+}
 
 # .ExternalHelp PSDocs-Help.xml
 function Document {
@@ -800,6 +826,12 @@ function InitEditorServices {
             'Note'
             'Warning'
             'Include'
+            'Export-PSDocumentConvention'
+        );
+
+        # Export variables
+        Export-ModuleMember -Variable @(
+            'PSDocs'
         );
     }
 }
@@ -807,6 +839,10 @@ function InitEditorServices {
 #
 # Editor services
 #
+
+# Define variables and types
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignment', '', Justification = 'Variable is used for editor discovery only.')]
+[PSDocs.Runtime.PSDocs]$PSDocs = New-Object -TypeName 'PSDocs.Runtime.PSDocs';
 
 if ($Null -ne (Get-Variable -Name psEditor -ErrorAction Ignore)) {
     InitEditorServices;

--- a/src/PSDocs/Pipeline/PipelineContext.cs
+++ b/src/PSDocs/Pipeline/PipelineContext.cs
@@ -16,13 +16,14 @@ namespace PSDocs.Pipeline
         internal readonly DocumentFilter Filter;
         internal readonly IPipelineWriter Writer;
         internal readonly InstanceNameBinder InstanceNameBinder;
+        internal readonly string[] Convention;
 
         private readonly Action<IDocumentResult, bool> _OutputVisitor;
 
         // Track whether Dispose has been called.
         private bool _Disposed;
 
-        public PipelineContext(PSDocumentOption option, IPipelineWriter writer, Action<IDocumentResult, bool> _Output, InstanceNameBinder instanceNameBinder)
+        public PipelineContext(PSDocumentOption option, IPipelineWriter writer, Action<IDocumentResult, bool> _Output, InstanceNameBinder instanceNameBinder, string[] convention)
         {
             Option = option;
             LanguageMode = option.Execution.LanguageMode.GetValueOrDefault(ExecutionOption.Default.LanguageMode.Value);
@@ -30,6 +31,7 @@ namespace PSDocs.Pipeline
             Writer = writer;
             InstanceNameBinder = instanceNameBinder;
             _OutputVisitor = _Output;
+            Convention = convention;
         }
 
         internal void WriteOutput(IDocumentResult result)

--- a/src/PSDocs/Processor/IDocumentResult.cs
+++ b/src/PSDocs/Processor/IDocumentResult.cs
@@ -1,9 +1,16 @@
-﻿namespace PSDocs.Processor
+﻿
+namespace PSDocs.Processor
 {
-    public interface IDocumentResult
+    internal interface IDocumentResult
     {
-        string Name { get; }
+        string InstanceName { get; }
+
+        string Extension { get; }
 
         string Culture { get; }
+
+        string OutputPath { get; }
+
+        string FullName { get; }
     }
 }

--- a/src/PSDocs/Processor/Markdown/MarkdownProcessorContext.cs
+++ b/src/PSDocs/Processor/Markdown/MarkdownProcessorContext.cs
@@ -1,4 +1,5 @@
-﻿using PSDocs.Configuration;
+﻿
+using PSDocs.Configuration;
 using PSDocs.Models;
 using System;
 using System.Text;

--- a/src/PSDocs/Runtime/DocumentContext.cs
+++ b/src/PSDocs/Runtime/DocumentContext.cs
@@ -1,0 +1,26 @@
+﻿
+using System.Collections;
+using System.Collections.Specialized;
+
+namespace PSDocs.Runtime
+{
+    internal sealed class DocumentContext
+    {
+        internal DocumentContext(RunspaceContext runspaceContext)
+        {
+            Culture = runspaceContext?.Culture;
+            Metadata = new OrderedDictionary();
+            Data = new Hashtable();
+        }
+
+        public string InstanceName { get; internal set; }
+
+        public string Culture { get; }
+
+        public string OutputPath { get; internal set; }
+
+        public OrderedDictionary Metadata { get; }
+
+        public Hashtable Data { get; }
+    }
+}

--- a/src/PSDocs/Runtime/HostState.cs
+++ b/src/PSDocs/Runtime/HostState.cs
@@ -55,7 +55,7 @@ namespace PSDocs.Runtime
             {
                 get
                 {
-                    return RunspaceContext.CurrentThread.InstanceName ?? RunspaceContext.CurrentThread.Builder.Name;
+                    return RunspaceContext.CurrentThread?.DocumentContext.InstanceName ?? RunspaceContext.CurrentThread.Builder.Name;
                 }
             }
         }
@@ -96,8 +96,10 @@ namespace PSDocs.Runtime
         private readonly static SessionStateCmdletEntry[] BuiltInCmdlets = new SessionStateCmdletEntry[]
         {
             new SessionStateCmdletEntry(LanguageCmdlets.NewDefinition, typeof(DefinitionCommand), null),
+            new SessionStateCmdletEntry(LanguageCmdlets.ExportConvention, typeof(ExportConventionCommand), null),
             new SessionStateCmdletEntry(LanguageCmdlets.NewSection, typeof(SectionCommand), null),
-            new SessionStateCmdletEntry(LanguageCmdlets.InvokeBlock, typeof(InvokeBlockCommand), null),
+            new SessionStateCmdletEntry(LanguageCmdlets.InvokeBlock, typeof(InvokeDocumentCommand), null),
+            new SessionStateCmdletEntry(LanguageCmdlets.InvokeConvention, typeof(InvokeConventionCommand), null),
             new SessionStateCmdletEntry(LanguageCmdlets.FormatBlockQuote, typeof(BlockQuoteCommand), null),
             new SessionStateCmdletEntry(LanguageCmdlets.FormatCode, typeof(CodeCommand), null),
             new SessionStateCmdletEntry(LanguageCmdlets.FormatList, typeof(ListCommand), null),

--- a/src/PSDocs/Runtime/LanguageScriptBlock.cs
+++ b/src/PSDocs/Runtime/LanguageScriptBlock.cs
@@ -1,0 +1,21 @@
+﻿
+using System.Collections;
+using System.Management.Automation;
+
+namespace PSDocs.Runtime
+{
+    internal sealed class LanguageScriptBlock
+    {
+        private readonly PowerShell _Block;
+
+        public LanguageScriptBlock(PowerShell block)
+        {
+            _Block = block;
+        }
+
+        public void Invoke()
+        {
+            _Block.Invoke();
+        }
+    }
+}

--- a/src/PSDocs/Runtime/PSDocs.cs
+++ b/src/PSDocs/Runtime/PSDocs.cs
@@ -1,4 +1,6 @@
 
+using PSDocs.Models;
+using System.Collections;
 using System.Management.Automation;
 using System.Threading;
 
@@ -7,17 +9,66 @@ namespace PSDocs.Runtime
     /// <summary>
     /// A set of context properties that are exposed at runtime through the $PSDocs variable.
     /// </summary>
-    public sealed class PSDocs
+    public sealed class PSDocs : ScopedItem
     {
-        private readonly RunspaceContext _Context;
-
         private Configuration _Configuration;
+        private PSDocsDocument _Document;
 
         public PSDocs() { }
 
         internal PSDocs(RunspaceContext context)
+            : base(context) { }
+
+        public sealed class PSDocsDocument : ScopedItem
         {
-            _Context = context;
+            internal PSDocsDocument(RunspaceContext context)
+                : base(context) { }
+
+            public string InstanceName
+            {
+                get
+                {
+                    RequireScope(RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess | RunspaceScope.Condition | RunspaceScope.Document);
+                    return GetContext().DocumentContext.InstanceName;
+                }
+                set
+                {
+                    RequireScope(RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess);
+                    if (string.IsNullOrEmpty(value))
+                        return;
+
+                    GetContext().DocumentContext.InstanceName = value;
+                }
+            }
+
+            public string OutputPath
+            {
+                get
+                {
+                    RequireScope(RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess | RunspaceScope.Condition | RunspaceScope.Document);
+                    return GetContext().DocumentContext.OutputPath;
+                }
+                set
+                {
+                    RequireScope(RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess);
+                    if (string.IsNullOrEmpty(value))
+                        return;
+
+                    GetContext().DocumentContext.OutputPath = value;
+                }
+            }
+
+            /// <summary>
+            /// Custom data for this document.
+            /// </summary>
+            public Hashtable Data
+            {
+                get
+                {
+                    RequireScope(RunspaceScope.Document | RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess);
+                    return GetContext().DocumentContext.Data;
+                }
+            }
         }
 
         /// <summary>
@@ -27,21 +78,10 @@ namespace PSDocs.Runtime
         {
             get
             {
+                RequireScope(RunspaceScope.Document | RunspaceScope.ConventionBegin | RunspaceScope.ConventionProcess | RunspaceScope.Condition);
                 return GetContext().TargetObject;
             }
         }
-
-        /// <summary>
-        /// The current culture.
-        /// </summary>
-        public string Culture
-        {
-            get
-            {
-                return GetContext().Culture;
-            }
-        }
-
 
         //public string Generator
         //{
@@ -58,6 +98,33 @@ namespace PSDocs.Runtime
         {
             get { return GetConfiguration(); }
         }
+
+        /// <summary>
+        /// The current culture.
+        /// </summary>
+        public string Culture
+        {
+            get
+            {
+                RequireScope(RunspaceScope.Document);
+                return GetContext().DocumentContext.Culture;
+            }
+        }
+
+        public PSDocsDocument Document
+        {
+            get { return GetDocument(); }
+        }
+
+        public IEnumerable Output
+        {
+            get
+            {
+                RequireScope(RunspaceScope.ConventionEnd);
+                return GetContext().Output;
+            }
+        }
+
         /// <summary>
         /// Format a string with arguments.
         /// </summary>
@@ -73,20 +140,26 @@ namespace PSDocs.Runtime
                 return string.Format(Thread.CurrentThread.CurrentCulture, value, args);
         }
 
-        private RunspaceContext GetContext()
-        {
-            if (_Context == null)
-                return RunspaceContext.CurrentThread;
-
-            return _Context;
-        }
+        #region Helper methods
 
         private Configuration GetConfiguration()
         {
+            RequireScope(RunspaceScope.All);
             if (_Configuration == null)
                 _Configuration = new Configuration(GetContext());
 
             return _Configuration;
         }
+
+        private PSDocsDocument GetDocument()
+        {
+            RequireScope(RunspaceScope.Runtime);
+            if (_Document == null)
+                _Document = new PSDocsDocument(GetContext());
+
+            return _Document;
+        }
+
+        #endregion Helper methods
     }
 }

--- a/src/PSDocs/Runtime/ScopedItem.cs
+++ b/src/PSDocs/Runtime/ScopedItem.cs
@@ -1,0 +1,40 @@
+﻿
+using PSDocs.Pipeline;
+
+namespace PSDocs.Runtime
+{
+    public abstract class ScopedItem
+    {
+        private readonly RunspaceContext _Context;
+
+        internal ScopedItem()
+        {
+
+        }
+
+        internal ScopedItem(RunspaceContext context)
+        {
+            _Context = context;
+        }
+
+        #region Helper methods
+
+        internal void RequireScope(RunspaceScope scope)
+        {
+            if (GetContext().IsScope(scope))
+                return;
+
+            throw new RuntimeException();
+        }
+
+        internal RunspaceContext GetContext()
+        {
+            if (_Context == null)
+                return RunspaceContext.CurrentThread;
+
+            return _Context;
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSDocs.Tests/FromFile.Conventions.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Conventions.Doc.ps1
@@ -1,0 +1,36 @@
+#
+# Conventions for unit testing
+#
+
+# Synopsis: An example naming convention.
+Export-PSDocumentConvention 'TestNamingConvention1' {
+    Write-Verbose -Message 'Convention process'
+    $PSDocs.Document.InstanceName = [String]::Concat($PSDocs.Document.Data.testName, '_', $PSDocs.Document.Data.count);
+    $newPath = Join-Path -Path $PSDocs.Document.OutputPath -ChildPath 'new';
+    $PSDocs.Document.OutputPath = $newPath;
+} -Begin {
+    Write-Verbose -Message 'Convention begin';
+    $PSDocs.Document.Data['count'] = 1;
+} -End {
+    Write-Verbose -Message "Convention end";
+    foreach ($output in $PSDocs.Output) {
+        $tocPath = Join-Path -Path $output.OutputPath -ChildPath 'toc.yaml';
+        Set-Content -Path $tocPath -Value '';
+    }
+}
+
+# Synopsis: An example naming convention.
+Export-PSDocumentConvention 'TestNamingConvention2' {
+    $PSDocs.Document.Data.count += 1;
+    Write-Verbose -Message 'Convention process'
+    $PSDocs.Document.InstanceName = [String]::Concat($PSDocs.Document.Data.testName, '_', $PSDocs.Document.Data.count);
+    $newPath = Join-Path -Path $PSDocs.Document.OutputPath -ChildPath 'new';
+    $PSDocs.Document.OutputPath = $newPath;
+}
+
+# Synopsis: A test document for testing conventions.
+Document 'ConventionDoc1' {
+    $PSDocs.Document.Data.testName = $PSDocs.TargetObject.Name;
+    $PSDocs.Document.Data.count += 1;
+    'Convention test'
+}

--- a/tests/PSDocs.Tests/FromFile.Doc.ps1
+++ b/tests/PSDocs.Tests/FromFile.Doc.ps1
@@ -1,4 +1,8 @@
 
+Export-PSDocumentConvention 'FromFileTest1' {
+
+}
+
 document 'FromFileTest1' {
     Title 'Test title'
     Metadata @{

--- a/tests/PSDocs.Tests/MarkdownProcessorTests.cs
+++ b/tests/PSDocs.Tests/MarkdownProcessorTests.cs
@@ -1,6 +1,7 @@
 using PSDocs.Configuration;
 using PSDocs.Models;
 using PSDocs.Processor.Markdown;
+using PSDocs.Runtime;
 using Xunit;
 
 namespace PSDocs
@@ -21,7 +22,7 @@ namespace PSDocs
 
         private static Document GetDocument()
         {
-            var result = new Document(null, null)
+            var result = new Document(new DocumentContext(null))
             {
                 Title = "Test document"
             };

--- a/tests/PSDocs.Tests/PSDocs.Conventions.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Conventions.Tests.ps1
@@ -1,0 +1,46 @@
+#
+# Unit tests for the PSDocs conventions
+#
+
+[CmdletBinding()]
+param ()
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSDocs) -Force;
+$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSDocs.Tests/Conventions;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+Describe 'PSDocs -- Conventions' -Tag Conventions {
+    $docFilePath = Join-Path -Path $here -ChildPath 'FromFile.Conventions.Doc.ps1';
+    $testObject = [PSCustomObject]@{
+        Name = 'TestObject'
+    }
+
+    Context '-Convention' {
+        $invokeParams = @{
+            Path = $docFilePath
+            InputObject = $testObject
+            OutputPath = $outputPath
+        }
+        It 'Generate output' {
+            # Singe convention
+            $result = Invoke-PSDocument @invokeParams -Name 'ConventionDoc1' -Convention 'TestNamingConvention1';
+            $result | Should -BeLike '*TestObject_2.md';
+            $testFile = Join-Path -Path $outputPath -ChildPath 'new/TestObject_2.md';
+            Test-Path -Path $testFile | Should -Be $True;
+            $tocFile = Join-Path -Path $outputPath -ChildPath 'new/toc.yaml';
+            Test-Path -Path $tocFile | Should -Be $True;
+
+            # Multiple conventions
+            $result = Invoke-PSDocument @invokeParams -Name 'ConventionDoc1' -Convention 'TestNamingConvention1', 'TestNamingConvention2';
+            $result | Should -BeLike '*TestObject_3.md';
+            $testFile = Join-Path -Path $outputPath -ChildPath 'new/new/TestObject_3.md';
+            Test-Path -Path $testFile | Should -Be $True;
+        }
+    }
+}

--- a/tests/PSDocs.Tests/PipelineTests.cs
+++ b/tests/PSDocs.Tests/PipelineTests.cs
@@ -15,12 +15,25 @@ namespace PSDocs
         [Fact]
         public void GetDocumentBuilder()
         {
-            var actual = HostHelper.GetDocumentBuilder(new RunspaceContext(new PipelineContext(GetOption(), null, null, null)), GetSource());
+            var actual = HostHelper.GetDocumentBuilder(new RunspaceContext(new PipelineContext(GetOption(), null, null, null, null)), GetSource());
             Assert.Equal(7, actual.Length);
         }
 
         [Fact]
         public void InvokePipeline()
+        {
+            var builder = PipelineBuilder.Invoke(GetSource(), GetOption(new string[] { "FromFileTest1" }), null, null);
+            var pipeline = builder.Build() as InvokePipeline;
+            var targetObject = PSObject.AsPSObject(new TestModel());
+
+            var actual = pipeline.BuildDocument(targetObject);
+            Assert.Single(actual);
+            Assert.Equal("Test title", actual[0].Title);
+            Assert.Equal("Test1", actual[0].Metadata["test"]);
+        }
+
+        [Fact]
+        public void InvokePipelineWithConvention()
         {
             var builder = PipelineBuilder.Invoke(GetSource(), GetOption(new string[] { "FromFileTest1" }), null, null);
             var pipeline = builder.Build() as InvokePipeline;


### PR DESCRIPTION
## PR Summary

- Added support for running custom actions using conventions.
  - Conventions provide `Begin`, `Process` and `End` blocks to hook into the document pipeline.
  - Name or change the output path of documents in `Begin` and `Process` blocks.
  - Generate table of contents (TOC) and perform publishing actions in `End` blocks.

Fixes #18 
Fixes #120 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
