### PR TITLE
Added support for document data and metadata output #148

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -2,12 +2,12 @@
 # CI pipeline for PSDocs
 
 variables:
-  version: '0.8.0'
+  version: '0.9.0'
   buildConfiguration: 'Release'
   disable.coverage.autogenerate: 'true'
   imageName: 'ubuntu-18.04'
 
- # Use build number format, i.e. 0.7.0-B2004001
+ # Use build number format, i.e. 0.9.0-B2004001
 name: $(version)-B$(date:yyMM)$(rev:rrr)
 
 trigger:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since v0.8.0:
+
+- General improvements:
+  - Added support for document data and metadata in `end` convention blocks. [#148](https://github.com/BernieWhite/PSDocs/issues/148)
+
 ## v0.8.0
 
 What's changed since v0.7.0:

--- a/src/PSDocs/Processor/IDocumentResult.cs
+++ b/src/PSDocs/Processor/IDocumentResult.cs
@@ -1,4 +1,7 @@
 ﻿
+using System.Collections;
+using System.Collections.Specialized;
+
 namespace PSDocs.Processor
 {
     internal interface IDocumentResult
@@ -12,5 +15,9 @@ namespace PSDocs.Processor
         string OutputPath { get; }
 
         string FullName { get; }
+
+        OrderedDictionary Metadata { get; }
+
+        Hashtable Data { get; }
     }
 }

--- a/src/PSDocs/Processor/Markdown/MarkdownProcessor.cs
+++ b/src/PSDocs/Processor/Markdown/MarkdownProcessor.cs
@@ -2,6 +2,8 @@
 using PSDocs.Configuration;
 using PSDocs.Models;
 using PSDocs.Runtime;
+using System.Collections;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 
@@ -27,6 +29,8 @@ namespace PSDocs.Processor.Markdown
                 Culture = documentContext.Culture;
                 OutputPath = PSDocumentOption.GetRootedPath(documentContext.OutputPath);
                 FullName = GetFullName();
+                Metadata = documentContext.Metadata;
+                Data = documentContext.Data;
             }
 
             [DebuggerStepThrough]
@@ -44,6 +48,10 @@ namespace PSDocs.Processor.Markdown
             public string OutputPath { get; }
 
             public string FullName { get; }
+
+            public OrderedDictionary Metadata { get; }
+
+            public Hashtable Data { get; }
 
             private string GetFullName()
             {

--- a/src/PSDocs/Runtime/PSDocs.cs
+++ b/src/PSDocs/Runtime/PSDocs.cs
@@ -1,5 +1,4 @@
 
-using PSDocs.Models;
 using System.Collections;
 using System.Management.Automation;
 using System.Threading;


### PR DESCRIPTION
## PR Summary

- Added support for document data and metadata in `end` convention blocks. #148

Fixes #148 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
