### PR TITLE
Pre-release v0.9.0-B2106004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
+## v0.9.0-B2106004 (pre-release)
+
 What's changed since pre-release v0.9.0-B2102002:
 
 - Engineering:
   - Bump YamlDotNet dependency to v11.2.0. [#165](https://github.com/BernieWhite/PSDocs/pull/165)
 
-## v0.9.0-B2102002
+## v0.9.0-B2102002 (pre-release)
 
 What's changed since v0.8.0:
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.9.0-B2102002:

- Engineering:
  - Bump YamlDotNet dependency to v11.2.0. #165

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
